### PR TITLE
feat(pulse): add read-only dbt artifact connector

### DIFF
--- a/.github/workflows/datametronome-ci.yml
+++ b/.github/workflows/datametronome-ci.yml
@@ -58,6 +58,7 @@ jobs:
           uv pip install -e ./datametronome/pulse/postgres-psycopg3
           uv pip install -e ./datametronome/pulse/postgres-sqlalchemy
           uv pip install -e ./datametronome/pulse/postgres
+          uv pip install -e ./datametronome/pulse/dbt
           uv pip install -e ./datametronome/brain/base
           uv pip install -e ./datametronome/podium
           # Install runtime deps not covered by -e
@@ -72,6 +73,7 @@ jobs:
           uv run pytest datametronome/pulse/postgres/tests/ -v
           uv run pytest datametronome/pulse/postgres-psycopg3/tests/ -v
           uv run pytest datametronome/pulse/postgres-sqlalchemy/tests/ -v
+          uv run pytest datametronome/pulse/dbt/tests/ -v --ignore=datametronome/pulse/dbt/tests/test_real_artifacts.py
           uv run pytest datametronome/podium/tests/test_unit.py -v
 
   release:

--- a/datametronome/podium/datametronome_podium/core/connector_factory.py
+++ b/datametronome/podium/datametronome_podium/core/connector_factory.py
@@ -126,7 +126,7 @@ def _build_dbt_connector(config: dict[str, Any], *, read_only: bool) -> Any:
     if not read_only:
         raise ValueError("dbt connector is read-only. Set read_only=True.")
 
-    from metronome_pulse_dbt import DbtReadonlyPulse
+    from metronome_pulse_dbt import DbtReadonlyPulse  # ty: ignore[unresolved-import]
 
     mode = config.get("mode", "local")
     return DbtReadonlyPulse(

--- a/datametronome/podium/datametronome_podium/core/connector_factory.py
+++ b/datametronome/podium/datametronome_podium/core/connector_factory.py
@@ -126,7 +126,7 @@ def _build_dbt_connector(config: dict[str, Any], *, read_only: bool) -> Any:
     if not read_only:
         raise ValueError("dbt connector is read-only. Set read_only=True.")
 
-    from metronome_pulse_dbt import DbtReadonlyPulse  # ty: ignore[unresolved-import]
+    from metronome_pulse_dbt import DbtReadonlyPulse
 
     mode = config.get("mode", "local")
     return DbtReadonlyPulse(

--- a/datametronome/podium/datametronome_podium/core/connector_factory.py
+++ b/datametronome/podium/datametronome_podium/core/connector_factory.py
@@ -70,6 +70,8 @@ def _build_connector(
         return _build_sqlite_connector(config, read_only=read_only)
     elif dst == "bigquery":
         return _build_bigquery_connector(config, read_only=read_only)
+    elif dst == "dbt":
+        return _build_dbt_connector(config, read_only=read_only)
     else:
         raise ValueError(f"Unsupported data source type: {dst!r}")
 
@@ -117,4 +119,22 @@ def _build_bigquery_connector(config: dict[str, Any], *, read_only: bool) -> Any
         credentials_json=config.get("credentials_json"),
         dataset=config.get("dataset"),
         location=config.get("location", "US"),
+    )
+
+
+def _build_dbt_connector(config: dict[str, Any], *, read_only: bool) -> Any:
+    if not read_only:
+        raise ValueError("dbt connector is read-only. Set read_only=True.")
+
+    from metronome_pulse_dbt import DbtReadonlyPulse
+
+    mode = config.get("mode", "local")
+    return DbtReadonlyPulse(
+        mode=mode,
+        project_path=config.get("project_path", ""),
+        target_path=config.get("target_path", "target"),
+        api_token=config.get("api_token", ""),
+        account_id=config.get("account_id", ""),
+        job_id=config.get("job_id", ""),
+        base_url=config.get("base_url", "https://cloud.getdbt.com/api/v2"),
     )

--- a/datametronome/podium/datametronome_podium/core/encryption.py
+++ b/datametronome/podium/datametronome_podium/core/encryption.py
@@ -25,6 +25,7 @@ SENSITIVE_FIELDS: dict[str, list[str]] = {
     "mongodb": ["password"],
     "snowflake": ["password", "private_key"],
     "bigquery": ["credentials_json"],
+    "dbt": ["api_token"],
 }
 
 # Fallback for unknown / future types

--- a/datametronome/podium/datametronome_podium/features/staves/model.py
+++ b/datametronome/podium/datametronome_podium/features/staves/model.py
@@ -14,6 +14,7 @@ SUPPORTED_DATA_SOURCES = [
     "redis",
     "snowflake",
     "bigquery",
+    "dbt",
     "api",
     "http",
 ]

--- a/datametronome/podium/datametronome_podium/features/staves/router.py
+++ b/datametronome/podium/datametronome_podium/features/staves/router.py
@@ -24,7 +24,7 @@ import datametronome_podium.features.staves.service as stave_svc
 router = APIRouter()
 
 VALID_DATA_SOURCE_TYPES = [
-    "postgres", "mysql", "mongodb", "sqlite", "redis", "snowflake", "bigquery"
+    "postgres", "mysql", "mongodb", "sqlite", "redis", "snowflake", "bigquery", "dbt"
 ]
 
 

--- a/datametronome/podium/datametronome_podium/features/staves/schema.py
+++ b/datametronome/podium/datametronome_podium/features/staves/schema.py
@@ -2,7 +2,7 @@
 from pydantic import BaseModel, field_validator
 
 VALID_DATA_SOURCE_TYPES = [
-    "postgres", "mysql", "mongodb", "sqlite", "redis", "snowflake", "bigquery"
+    "postgres", "mysql", "mongodb", "sqlite", "redis", "snowflake", "bigquery", "dbt"
 ]
 
 

--- a/datametronome/podium/datametronome_podium/features/staves/service.py
+++ b/datametronome/podium/datametronome_podium/features/staves/service.py
@@ -89,6 +89,8 @@ async def _call_list_tables(connector: Any, stave: Stave) -> list[str]:
     if stave.data_source_type in ("postgres", "postgresql"):
         schema = stave.connection_config.get("schema", "public")
         return await connector.list_tables(schema)
+    if stave.data_source_type == "dbt":
+        return await connector.list_tables()
     return await connector.list_tables()
 
 
@@ -219,6 +221,13 @@ async def _fetch_preview_data(stave: Stave, table_name: str, limit: int) -> list
             return await connector.query_with_params(
                 f"SELECT * FROM {qtbl} LIMIT $1", [limit]
             )
+        finally:
+            await connector.close()
+
+    if dst == "dbt":
+        connector = await create_connector(dst, config, read_only=True)
+        try:
+            return await connector.query({"table": table_name, "limit": limit})
         finally:
             await connector.close()
 

--- a/datametronome/podium/datametronome_podium/services/connection_tester.py
+++ b/datametronome/podium/datametronome_podium/services/connection_tester.py
@@ -496,7 +496,7 @@ class ConnectionTester:
     async def _test_dbt_connection(self, stave: Stave) -> dict[str, Any]:
         """Test dbt artifact connection using DbtReadonlyPulse."""
         try:
-            from metronome_pulse_dbt import DbtReadonlyPulse  # ty: ignore[unresolved-import]
+            from metronome_pulse_dbt import DbtReadonlyPulse
 
             config = stave.connection_config
 

--- a/datametronome/podium/datametronome_podium/services/connection_tester.py
+++ b/datametronome/podium/datametronome_podium/services/connection_tester.py
@@ -496,7 +496,7 @@ class ConnectionTester:
     async def _test_dbt_connection(self, stave: Stave) -> dict[str, Any]:
         """Test dbt artifact connection using DbtReadonlyPulse."""
         try:
-            from metronome_pulse_dbt import DbtReadonlyPulse
+            from metronome_pulse_dbt import DbtReadonlyPulse  # ty: ignore[unresolved-import]
 
             config = stave.connection_config
 

--- a/datametronome/podium/datametronome_podium/services/connection_tester.py
+++ b/datametronome/podium/datametronome_podium/services/connection_tester.py
@@ -54,6 +54,8 @@ class ConnectionTester:
                 result = await self._test_mongodb_connection(stave)
             elif stave.data_source_type == "bigquery":
                 result = await self._test_bigquery_connection(stave)
+            elif stave.data_source_type == "dbt":
+                result = await self._test_dbt_connection(stave)
             elif stave.data_source_type in ["api", "http"]:
                 result = await self._test_api_connection(stave)
             else:
@@ -488,6 +490,57 @@ class ConnectionTester:
             return {
                 "success": False,
                 "message": f"BigQuery connection failed: {str(e)}",
+                "metadata": {},
+            }
+
+    async def _test_dbt_connection(self, stave: Stave) -> dict[str, Any]:
+        """Test dbt artifact connection using DbtReadonlyPulse."""
+        try:
+            from metronome_pulse_dbt import DbtReadonlyPulse
+
+            config = stave.connection_config
+
+            connector = DbtReadonlyPulse(
+                mode=config.get("mode", "local"),
+                project_path=config.get("project_path", ""),
+                target_path=config.get("target_path", "target"),
+                api_token=config.get("api_token", ""),
+                account_id=config.get("account_id", ""),
+                job_id=config.get("job_id", ""),
+                base_url=config.get(
+                    "base_url", "https://cloud.getdbt.com/api/v2"
+                ),
+            )
+
+            await connector.connect()
+
+            models = await connector.query("models")
+            sources = await connector.query("sources")
+            tests = await connector.query("tests")
+
+            await connector.close()
+
+            return {
+                "success": True,
+                "message": "dbt connection successful",
+                "metadata": {
+                    "mode": config.get("mode", "local"),
+                    "model_count": len(models),
+                    "source_count": len(sources),
+                    "test_count": len(tests),
+                },
+            }
+
+        except ImportError:
+            return {
+                "success": False,
+                "message": "metronome_pulse_dbt not installed. Install with: pip install metronome-pulse-dbt",
+                "metadata": {},
+            }
+        except Exception as e:
+            return {
+                "success": False,
+                "message": f"dbt connection failed: {str(e)}",
                 "metadata": {},
             }
 

--- a/datametronome/podium/tests/core/test_connector_factory_dbt.py
+++ b/datametronome/podium/tests/core/test_connector_factory_dbt.py
@@ -38,7 +38,7 @@ class TestBuildDbtConnector:
                     read_only=True,
                 )
             except ImportError:
-                pytest.skip("metronome_pulse_dbt not installed")
+                pytest.skip("metronome_pulse_dbt not installed")  # ty: ignore[too-many-positional-arguments]
 
     def test_dbt_cloud_mode(self):
         """Verify cloud config keys are forwarded correctly."""
@@ -60,7 +60,7 @@ class TestBuildDbtConnector:
                     read_only=True,
                 )
             except ImportError:
-                pytest.skip("metronome_pulse_dbt not installed")
+                pytest.skip("metronome_pulse_dbt not installed")  # ty: ignore[too-many-positional-arguments]
 
 
 class TestDbtInStaveTypes:

--- a/datametronome/podium/tests/core/test_connector_factory_dbt.py
+++ b/datametronome/podium/tests/core/test_connector_factory_dbt.py
@@ -1,7 +1,7 @@
 """Tests for dbt connector factory integration."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -11,22 +11,20 @@ from datametronome_podium.core.connector_factory import _build_connector
 class TestBuildDbtConnector:
     """Test _build_connector with dst='dbt'."""
 
-    @patch("datametronome_podium.core.connector_factory._build_dbt_connector")
-    def test_dispatches_to_dbt_builder(self, mock_build):
-        mock_build.return_value = MagicMock()
-        _build_connector("dbt", {"mode": "local", "project_path": "/tmp"}, read_only=True)
-        mock_build.assert_called_once_with(
-            {"mode": "local", "project_path": "/tmp"}, read_only=True
-        )
+    def test_dispatches_to_dbt_builder(self):
+        with patch("datametronome_podium.core.connector_factory._build_dbt_connector") as mock_build:
+            mock_build.return_value = MagicMock()
+            _build_connector("dbt", {"mode": "local", "project_path": "/tmp"}, read_only=True)
+            mock_build.assert_called_once_with(
+                {"mode": "local", "project_path": "/tmp"}, read_only=True
+            )
 
     def test_dbt_read_only_false_raises(self):
         with pytest.raises(ValueError, match="read-only"):
             _build_connector("dbt", {"mode": "local", "project_path": "/tmp"}, read_only=False)
 
-    @patch("datametronome_podium.core.connector_factory.DbtReadonlyPulse", create=True)
-    def test_dbt_local_mode(self, _mock_cls):
+    def test_dbt_local_mode(self):
         """Verify local config keys are forwarded correctly."""
-        # Use a real import to test the actual builder
         from datametronome_podium.core.connector_factory import _build_dbt_connector
 
         with patch(
@@ -42,8 +40,7 @@ class TestBuildDbtConnector:
             except ImportError:
                 pytest.skip("metronome_pulse_dbt not installed")
 
-    @patch("datametronome_podium.core.connector_factory.DbtReadonlyPulse", create=True)
-    def test_dbt_cloud_mode(self, _mock_cls):
+    def test_dbt_cloud_mode(self):
         """Verify cloud config keys are forwarded correctly."""
         from datametronome_podium.core.connector_factory import _build_dbt_connector
 

--- a/datametronome/podium/tests/core/test_connector_factory_dbt.py
+++ b/datametronome/podium/tests/core/test_connector_factory_dbt.py
@@ -1,0 +1,100 @@
+"""Tests for dbt connector factory integration."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from datametronome_podium.core.connector_factory import _build_connector
+
+
+class TestBuildDbtConnector:
+    """Test _build_connector with dst='dbt'."""
+
+    @patch("datametronome_podium.core.connector_factory._build_dbt_connector")
+    def test_dispatches_to_dbt_builder(self, mock_build):
+        mock_build.return_value = MagicMock()
+        _build_connector("dbt", {"mode": "local", "project_path": "/tmp"}, read_only=True)
+        mock_build.assert_called_once_with(
+            {"mode": "local", "project_path": "/tmp"}, read_only=True
+        )
+
+    def test_dbt_read_only_false_raises(self):
+        with pytest.raises(ValueError, match="read-only"):
+            _build_connector("dbt", {"mode": "local", "project_path": "/tmp"}, read_only=False)
+
+    @patch("datametronome_podium.core.connector_factory.DbtReadonlyPulse", create=True)
+    def test_dbt_local_mode(self, _mock_cls):
+        """Verify local config keys are forwarded correctly."""
+        # Use a real import to test the actual builder
+        from datametronome_podium.core.connector_factory import _build_dbt_connector
+
+        with patch(
+            "datametronome_podium.core.connector_factory.DbtReadonlyPulse",
+            create=True,
+        ) as mock_cls:
+            mock_cls.return_value = MagicMock()
+            try:
+                _build_dbt_connector(
+                    {"mode": "local", "project_path": "/my/dbt", "target_path": "build"},
+                    read_only=True,
+                )
+            except ImportError:
+                pytest.skip("metronome_pulse_dbt not installed")
+
+    @patch("datametronome_podium.core.connector_factory.DbtReadonlyPulse", create=True)
+    def test_dbt_cloud_mode(self, _mock_cls):
+        """Verify cloud config keys are forwarded correctly."""
+        from datametronome_podium.core.connector_factory import _build_dbt_connector
+
+        with patch(
+            "datametronome_podium.core.connector_factory.DbtReadonlyPulse",
+            create=True,
+        ) as mock_cls:
+            mock_cls.return_value = MagicMock()
+            try:
+                _build_dbt_connector(
+                    {
+                        "mode": "cloud",
+                        "api_token": "tok",
+                        "account_id": "123",
+                        "job_id": "456",
+                    },
+                    read_only=True,
+                )
+            except ImportError:
+                pytest.skip("metronome_pulse_dbt not installed")
+
+
+class TestDbtInStaveTypes:
+    """Verify 'dbt' is accepted as a valid data source type."""
+
+    def test_model_accepts_dbt(self):
+        from datametronome_podium.features.staves.model import SUPPORTED_DATA_SOURCES
+
+        assert "dbt" in SUPPORTED_DATA_SOURCES
+
+    def test_schema_accepts_dbt(self):
+        from datametronome_podium.features.staves.schema import VALID_DATA_SOURCE_TYPES
+
+        assert "dbt" in VALID_DATA_SOURCE_TYPES
+
+    def test_stave_model_validates_dbt(self):
+        from datametronome_podium.features.staves.model import Stave
+
+        stave = Stave(
+            name="my-dbt",
+            data_source_type="dbt",
+            connection_config={"mode": "local", "project_path": "/tmp"},
+        )
+        assert stave.data_source_type == "dbt"
+
+
+class TestDbtEncryption:
+    """Verify dbt sensitive fields are configured."""
+
+    def test_dbt_sensitive_fields(self):
+        from datametronome_podium.core.encryption import SENSITIVE_FIELDS
+
+        assert "dbt" in SENSITIVE_FIELDS
+        assert "api_token" in SENSITIVE_FIELDS["dbt"]

--- a/datametronome/pulse/dbt/README.md
+++ b/datametronome/pulse/dbt/README.md
@@ -1,0 +1,119 @@
+# metronome-pulse-dbt
+
+Read-only dbt artifact connector for DataMetronome. Exposes dbt project metadata
+(manifest, run results, catalog) as virtual queryable tables via the Pulse connector
+interface.
+
+## Installation
+
+```bash
+pip install metronome-pulse-dbt
+```
+
+## Configuration
+
+### Local Mode
+
+Reads dbt artifacts from the filesystem (`target/` directory):
+
+```json
+{
+  "mode": "local",
+  "project_path": "/path/to/dbt/project",
+  "target_path": "target"
+}
+```
+
+`target_path` defaults to `"target"`. The connector reads:
+- `manifest.json` (required)
+- `run_results.json` (optional)
+- `catalog.json` (optional — run `dbt docs generate` to produce this)
+
+### Cloud Mode
+
+Fetches artifacts from the dbt Cloud API:
+
+```json
+{
+  "mode": "cloud",
+  "api_token": "your-dbt-cloud-token",
+  "account_id": "12345",
+  "job_id": "67890"
+}
+```
+
+The connector finds the latest completed run for the given job and fetches its artifacts.
+
+## Virtual Tables
+
+The connector exposes dbt metadata as queryable virtual tables:
+
+| Table | Source Artifact | Key Columns |
+|---|---|---|
+| `models` | manifest.json | unique_id, name, schema, database, materialization, tags, description, depends_on, path |
+| `sources` | manifest.json | unique_id, name, source_name, schema, database, identifier, freshness_warn_after, freshness_error_after |
+| `tests` | manifest.json | unique_id, name, test_type, model, column_name, severity, tags |
+| `test_results` | run_results.json | unique_id, status, execution_time, message, failures, timestamp |
+| `columns` | catalog.json | model_unique_id, model_name, column_name, column_type, description |
+| `exposures` | manifest.json | unique_id, name, type, owner, depends_on |
+
+## Querying
+
+### By table name
+
+```python
+rows = await connector.query("models")
+```
+
+### With filters
+
+```python
+rows = await connector.query({
+    "table": "models",
+    "where": {"materialization": "table"},
+    "columns": ["name", "schema"],
+    "order_by": "name",
+    "limit": 10,
+})
+```
+
+### Where clause
+
+- **Equality**: `{"materialization": "table"}` — matches rows where the field equals the value
+- **List containment**: `{"tags": "finance"}` — matches rows where the value is in the list field
+
+### Ordering
+
+- Ascending: `"order_by": "name"`
+- Descending: `"order_by": "-name"`
+
+## Introspection
+
+- `list_tables()` — returns dbt model names (not virtual table names)
+- `get_table_info(model_name)` — returns column info from catalog for the given model
+
+## Usage with DataMetronome
+
+Create a stave with `data_source_type: "dbt"`:
+
+```bash
+curl -X POST http://localhost:8001/api/v1/staves \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My dbt Project",
+    "data_source_type": "dbt",
+    "connection_config": {
+      "mode": "local",
+      "project_path": "/path/to/dbt/project"
+    }
+  }'
+```
+
+Then test the connection and list tables as usual via the stave action endpoints.
+
+## Limitations
+
+- **Read-only**: write, execute, and transaction methods raise `NotImplementedError`
+- **Metadata only**: queries return dbt metadata, not warehouse data
+- **No SQL**: SQL strings are rejected with a helpful error; use table names or query dicts

--- a/datametronome/pulse/dbt/metronome_pulse_dbt/__init__.py
+++ b/datametronome/pulse/dbt/metronome_pulse_dbt/__init__.py
@@ -1,0 +1,6 @@
+"""dbt artifact connector for DataMetronome — read-only metadata access."""
+
+from .connector import DbtReadonlyPulse
+
+__version__ = "0.1.0"
+__all__ = ["DbtReadonlyPulse"]

--- a/datametronome/pulse/dbt/metronome_pulse_dbt/artifact_reader.py
+++ b/datametronome/pulse/dbt/metronome_pulse_dbt/artifact_reader.py
@@ -1,0 +1,195 @@
+"""Artifact reader implementations for dbt local projects and dbt Cloud."""
+
+import asyncio
+import json
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from .exceptions import ArtifactNotFoundError, ArtifactParseError, CloudApiError
+
+
+class ArtifactReader(ABC):
+    """Abstract base for reading dbt JSON artifacts."""
+
+    @abstractmethod
+    async def read_manifest(self) -> dict[str, Any]:
+        """Return parsed manifest.json contents.
+
+        Raises ArtifactNotFoundError if the artifact is missing — manifest is
+        mandatory for any dbt project introspection.
+        """
+        ...
+
+    @abstractmethod
+    async def read_run_results(self) -> dict[str, Any] | None:
+        """Return parsed run_results.json, or None if not available.
+
+        run_results is produced only after a dbt run/test, so its absence is
+        normal and callers must handle None.
+        """
+        ...
+
+    @abstractmethod
+    async def read_catalog(self) -> dict[str, Any] | None:
+        """Return parsed catalog.json, or None if not available.
+
+        catalog.json is produced only after `dbt docs generate`, so callers
+        must handle None.
+        """
+        ...
+
+    @abstractmethod
+    async def is_available(self) -> bool:
+        """Return True if the artifact source is accessible (manifest present)."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Local filesystem reader
+# ---------------------------------------------------------------------------
+
+
+def _read_json_sync(path: Path) -> dict[str, Any]:
+    """Blocking JSON read — run inside an executor to stay off the event loop."""
+    raw = path.read_text(encoding="utf-8")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ArtifactParseError(f"Invalid JSON in {path}: {exc}") from exc
+
+
+class LocalArtifactReader(ArtifactReader):
+    """Read dbt artifacts from a local filesystem target directory."""
+
+    def __init__(self, project_path: str, target_path: str = "target") -> None:
+        self._target_dir = Path(project_path) / target_path
+
+    def _artifact_path(self, filename: str) -> Path:
+        return self._target_dir / filename
+
+    async def _read_file(self, path: Path) -> dict[str, Any]:
+        """Offload blocking file I/O to a thread so the event loop stays free."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, _read_json_sync, path)
+
+    async def read_manifest(self) -> dict[str, Any]:
+        path = self._artifact_path("manifest.json")
+        if not path.exists():
+            raise ArtifactNotFoundError(f"manifest.json not found at {path}")
+        return await self._read_file(path)
+
+    async def read_run_results(self) -> dict[str, Any] | None:
+        path = self._artifact_path("run_results.json")
+        if not path.exists():
+            return None
+        return await self._read_file(path)
+
+    async def read_catalog(self) -> dict[str, Any] | None:
+        path = self._artifact_path("catalog.json")
+        if not path.exists():
+            return None
+        return await self._read_file(path)
+
+    async def is_available(self) -> bool:
+        return self._artifact_path("manifest.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# dbt Cloud API reader
+# ---------------------------------------------------------------------------
+
+
+class CloudArtifactReader(ArtifactReader):
+    """Read dbt artifacts from the dbt Cloud API.
+
+    Fetches artifacts from the most recently finished run for a given job.
+    Auth uses a token header — dbt Cloud does not support basic auth for the
+    v2 API.
+    """
+
+    def __init__(
+        self,
+        api_token: str,
+        account_id: str,
+        job_id: str,
+        base_url: str = "https://cloud.getdbt.com/api/v2",
+    ) -> None:
+        self._api_token = api_token
+        self._account_id = account_id
+        self._job_id = job_id
+        self._base_url = base_url.rstrip("/")
+        self._headers = {"Authorization": f"Token {api_token}"}
+
+    async def _get_latest_run_id(self) -> str:
+        """Fetch the most recently finished run ID for the configured job."""
+        url = (
+            f"{self._base_url}/accounts/{self._account_id}/runs/"
+            f"?job_definition_id={self._job_id}&order_by=-finished_at&limit=1"
+        )
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=self._headers)
+        self._raise_for_auth(response)
+        response.raise_for_status()
+        data = response.json()
+        return str(data["data"][0]["id"])
+
+    async def _fetch_artifact(self, filename: str) -> dict[str, Any] | None:
+        """Fetch a single artifact by filename from the latest run.
+
+        Returns None for 404 (artifact not generated for this run).
+        Raises CloudApiError on auth errors; raises httpx errors for other
+        non-200 responses.
+        """
+        run_id = await self._get_latest_run_id()
+        url = (
+            f"{self._base_url}/accounts/{self._account_id}"
+            f"/runs/{run_id}/artifacts/{filename}"
+        )
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=self._headers)
+        self._raise_for_auth(response)
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        try:
+            return response.json()
+        except Exception as exc:
+            raise ArtifactParseError(
+                f"Failed to parse {filename} from dbt Cloud response"
+            ) from exc
+
+    def _raise_for_auth(self, response: httpx.Response) -> None:
+        """Convert 401/403 responses to CloudApiError with the status code."""
+        if response.status_code in (401, 403):
+            raise CloudApiError(
+                f"dbt Cloud auth failed ({response.status_code})",
+                status_code=response.status_code,
+            )
+
+    async def read_manifest(self) -> dict[str, Any]:
+        result = await self._fetch_artifact("manifest.json")
+        if result is None:
+            raise ArtifactNotFoundError("manifest.json not found in dbt Cloud run")
+        return result
+
+    async def read_run_results(self) -> dict[str, Any] | None:
+        return await self._fetch_artifact("run_results.json")
+
+    async def read_catalog(self) -> dict[str, Any] | None:
+        return await self._fetch_artifact("catalog.json")
+
+    async def is_available(self) -> bool:
+        """Return True if the runs list endpoint responds successfully."""
+        url = (
+            f"{self._base_url}/accounts/{self._account_id}/runs/"
+            f"?job_definition_id={self._job_id}&order_by=-finished_at&limit=1"
+        )
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(url, headers=self._headers)
+            return response.status_code == 200
+        except httpx.HTTPError:
+            return False

--- a/datametronome/pulse/dbt/metronome_pulse_dbt/connector.py
+++ b/datametronome/pulse/dbt/metronome_pulse_dbt/connector.py
@@ -1,0 +1,199 @@
+"""DbtReadonlyPulse — read-only Pulse connector for dbt artifacts."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from metronome_pulse_core.interfaces import Pulse, Readable
+
+from .artifact_reader import ArtifactReader, CloudArtifactReader, LocalArtifactReader
+from .parsers import (
+    parse_columns,
+    parse_exposures,
+    parse_models,
+    parse_sources,
+    parse_test_results,
+    parse_tests,
+)
+from .virtual_tables import VirtualTableEngine
+
+logger = logging.getLogger(__name__)
+
+
+class DbtReadonlyPulse(Pulse, Readable):
+    """Read-only connector that exposes dbt project metadata as virtual tables.
+
+    Supports two modes:
+    - local: reads artifacts from filesystem ({project_path}/{target_path}/)
+    - cloud: fetches artifacts from dbt Cloud API
+
+    Connection config:
+        Local:  DbtReadonlyPulse(mode="local", project_path="/path/to/dbt")
+        Cloud:  DbtReadonlyPulse(mode="cloud", api_token="...", account_id="123", job_id="456")
+    """
+
+    def __init__(
+        self,
+        *,
+        mode: str = "local",
+        project_path: str = "",
+        target_path: str = "target",
+        api_token: str = "",
+        account_id: str = "",
+        job_id: str = "",
+        base_url: str = "https://cloud.getdbt.com/api/v2",
+        **kwargs: Any,
+    ) -> None:
+        self._mode = mode
+        self._connected = False
+        self._engine = VirtualTableEngine()
+        self._reader: ArtifactReader
+
+        if mode == "local":
+            if not project_path:
+                raise ValueError("project_path is required for local mode")
+            self._reader = LocalArtifactReader(project_path, target_path)
+        elif mode == "cloud":
+            # All three cloud credentials are required — partial config is not valid
+            if not all([api_token, account_id, job_id]):
+                raise ValueError(
+                    "api_token, account_id, and job_id are required for cloud mode"
+                )
+            self._reader = CloudArtifactReader(api_token, account_id, job_id, base_url)
+        else:
+            raise ValueError(f"Unsupported mode: {mode!r}. Use 'local' or 'cloud'.")
+
+    # --- Lifecycle ---
+
+    async def connect(self) -> None:
+        """Load artifacts and build virtual tables."""
+        if self._connected:
+            return
+
+        manifest = await self._reader.read_manifest()
+        run_results = await self._reader.read_run_results()
+        catalog = await self._reader.read_catalog()
+
+        self._engine.register_table("models", parse_models(manifest))
+        self._engine.register_table("sources", parse_sources(manifest))
+        self._engine.register_table("tests", parse_tests(manifest))
+        self._engine.register_table("exposures", parse_exposures(manifest))
+
+        # run_results and catalog are optional — register only when available
+        if run_results:
+            self._engine.register_table("test_results", parse_test_results(run_results))
+        if catalog:
+            self._engine.register_table("columns", parse_columns(catalog))
+
+        self._connected = True
+        logger.info(
+            "dbt connector ready — %d virtual tables loaded",
+            len(self._engine.list_tables()),
+        )
+
+    async def close(self) -> None:
+        self._connected = False
+
+    async def is_connected(self) -> bool:
+        return self._connected
+
+    # --- Read ---
+
+    async def query(self, query_config: str | dict) -> list[dict]:
+        """Query virtual tables by table name string or query dict."""
+        if not self._connected:
+            raise RuntimeError("Not connected. Call connect() first.")
+        return self._engine.query(query_config)
+
+    async def query_with_params(self, sql: str, params: list[Any] | None = None) -> list[dict]:
+        """Delegate to query() for plain identifiers; reject SQL strings with a helpful error.
+
+        The params argument is accepted for protocol compatibility but ignored —
+        virtual table queries do not support SQL parameter binding.
+        """
+        stripped = sql.strip()
+        # Plain identifier has no spaces and doesn't start with a SQL keyword
+        if stripped and " " not in stripped and not _is_sql(stripped):
+            return await self.query(stripped)
+        raise ValueError(
+            f"SQL queries are not supported by the dbt connector. "
+            f"Pass a virtual table name instead."
+        )
+
+    # --- Introspection ---
+
+    async def list_tables(self) -> list[str]:
+        """Return dbt model names (the user's data objects, not internal virtual table names).
+
+        This contract mirrors other connectors: list_tables exposes what the user
+        cares about (their models), not the connector's internal organisation.
+        """
+        if not self._connected:
+            raise RuntimeError("Not connected. Call connect() first.")
+        models = self._engine.query("models")
+        return [m["name"] for m in models]
+
+    async def get_table_info(self, table_name: str) -> list[dict]:
+        """Return column info for a dbt model by name.
+
+        Uses the columns virtual table populated from catalog.json.
+        Matching is case-insensitive because some warehouses (e.g. Snowflake)
+        uppercase catalog names while manifest names stay lowercase.
+        Returns an empty list when no catalog was loaded or the model
+        has no column metadata.
+        """
+        if not self._connected:
+            raise RuntimeError("Not connected. Call connect() first.")
+        try:
+            all_cols = self._engine.query("columns")
+        except ValueError:
+            return []
+        needle = table_name.lower()
+        return [
+            {"column_name": c["column_name"], "column_type": c["column_type"]}
+            for c in all_cols
+            if c.get("model_name", "").lower() == needle
+        ]
+
+    # --- Write (not supported) ---
+
+    async def execute(self, sql: str, params: list[Any] | None = None) -> int:
+        raise NotImplementedError("dbt connector is read-only")
+
+    async def execute_many(self, sql: str, params_list: list[list[Any]]) -> None:
+        raise NotImplementedError("dbt connector is read-only")
+
+    async def write(
+        self,
+        data: list[dict],
+        destination: str,
+        config: dict | None = None,
+    ) -> None:
+        raise NotImplementedError("dbt connector is read-only")
+
+    # --- Transactions (no-ops for read-only connector) ---
+
+    async def begin_transaction(self) -> None:
+        pass
+
+    async def commit_transaction(self) -> None:
+        pass
+
+    async def rollback_transaction(self) -> None:
+        pass
+
+    # --- Context manager ---
+
+    async def __aenter__(self) -> "DbtReadonlyPulse":
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close()
+
+
+def _is_sql(text: str) -> bool:
+    """Return True if text starts with a SQL keyword (case-insensitive)."""
+    _SQL_PREFIXES = ("SELECT", "INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "ALTER")
+    upper = text.upper()
+    return any(upper.startswith(prefix) for prefix in _SQL_PREFIXES)

--- a/datametronome/pulse/dbt/metronome_pulse_dbt/exceptions.py
+++ b/datametronome/pulse/dbt/metronome_pulse_dbt/exceptions.py
@@ -1,0 +1,29 @@
+"""Custom exceptions for the dbt artifact connector."""
+
+
+class DbtConnectorError(Exception):
+    """Base exception for all dbt connector errors."""
+
+
+class ArtifactNotFoundError(DbtConnectorError):
+    """Raised when a required artifact (e.g. manifest.json) is missing.
+
+    manifest.json is the only required artifact — run_results and catalog
+    are optional and return None instead of raising.
+    """
+
+
+class ArtifactParseError(DbtConnectorError):
+    """Raised when an artifact file exists but cannot be parsed as valid JSON."""
+
+
+class CloudApiError(DbtConnectorError):
+    """Raised when the dbt Cloud API returns an unexpected response.
+
+    status_code carries the HTTP status so callers can distinguish auth
+    failures (401/403) from transient server errors (5xx).
+    """
+
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code

--- a/datametronome/pulse/dbt/metronome_pulse_dbt/parsers.py
+++ b/datametronome/pulse/dbt/metronome_pulse_dbt/parsers.py
@@ -1,0 +1,148 @@
+"""Parsers that normalize dbt artifact JSON into flat row dicts.
+
+Each function accepts the raw parsed JSON dict for one artifact file and
+returns a list of row dicts — one row per logical entity. All field access
+uses .get() so the parsers tolerate missing keys across dbt schema versions
+(v9 through v12 differ in which fields are present).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def parse_models(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract models from manifest.json nodes where resource_type == 'model'."""
+    rows = []
+    for uid, node in manifest.get("nodes", {}).items():
+        if node.get("resource_type") != "model":
+            continue
+        rows.append({
+            "unique_id": uid,
+            "name": node.get("name", ""),
+            "schema": node.get("schema", ""),
+            "database": node.get("database", ""),
+            # config.materialized is the canonical field; absent in older schemas
+            "materialization": node.get("config", {}).get("materialized", ""),
+            "tags": node.get("tags", []),
+            "description": node.get("description", ""),
+            "depends_on": node.get("depends_on", {}).get("nodes", []),
+            "path": node.get("path", ""),
+        })
+    return rows
+
+
+def parse_sources(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract sources from manifest.json sources section."""
+    rows = []
+    for uid, source in manifest.get("sources", {}).items():
+        freshness = source.get("freshness", {})
+        # identifier falls back to name when not explicitly set in dbt YAML
+        rows.append({
+            "unique_id": uid,
+            "name": source.get("name", ""),
+            "source_name": source.get("source_name", ""),
+            "schema": source.get("schema", ""),
+            "database": source.get("database", ""),
+            "identifier": source.get("identifier", source.get("name", "")),
+            "freshness_warn_after": freshness.get("warn_after"),
+            "freshness_error_after": freshness.get("error_after"),
+        })
+    return rows
+
+
+def parse_tests(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract tests from manifest.json nodes where resource_type == 'test'.
+
+    dbt has two test kinds:
+      - generic (schema) tests: defined in YAML, carry test_metadata
+      - singular (data) tests: standalone .sql files, no test_metadata
+    """
+    rows = []
+    for uid, node in manifest.get("nodes", {}).items():
+        if node.get("resource_type") != "test":
+            continue
+        test_metadata = node.get("test_metadata", {})
+        # Presence of test_metadata distinguishes generic from singular tests
+        test_type = "generic" if test_metadata else "singular"
+
+        # First node in depends_on is the model under test (may be absent for
+        # singular tests that join multiple models)
+        depends_on_nodes = node.get("depends_on", {}).get("nodes", [])
+        model = depends_on_nodes[0] if depends_on_nodes else ""
+
+        rows.append({
+            "unique_id": uid,
+            "name": node.get("name", ""),
+            "test_type": test_type,
+            "model": model,
+            "column_name": node.get("column_name", ""),
+            # severity defaults to ERROR per dbt spec when config is absent
+            "severity": node.get("config", {}).get("severity", "ERROR"),
+            "tags": node.get("tags", []),
+        })
+    return rows
+
+
+def parse_test_results(run_results: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract test results from run_results.json, filtering to test nodes only.
+
+    run_results.json mixes model runs and test runs; unique_id prefix 'test.'
+    is the only reliable discriminator between the two.
+    """
+    rows = []
+    # generated_at lives under metadata, not per-result; attach it to every row
+    timestamp = run_results.get("metadata", {}).get("generated_at", "")
+    for result in run_results.get("results", []):
+        uid = result.get("unique_id", "")
+        if not uid.startswith("test."):
+            continue
+        rows.append({
+            "unique_id": uid,
+            "status": result.get("status", ""),
+            "execution_time": result.get("execution_time", 0.0),
+            "message": result.get("message", ""),
+            "failures": result.get("failures"),
+            "timestamp": timestamp,
+        })
+    return rows
+
+
+def parse_columns(catalog: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract column info from catalog.json nodes and sources.
+
+    catalog.json organises entries under 'nodes' (models/seeds/snapshots) and
+    'sources', both with the same structure. We flatten both into one list so
+    callers don't need to treat them differently.
+    """
+    rows = []
+    for section in ("nodes", "sources"):
+        for uid, entry in catalog.get(section, {}).items():
+            model_name = entry.get("metadata", {}).get("name", "")
+            for col_name, col_info in entry.get("columns", {}).items():
+                rows.append({
+                    "model_unique_id": uid,
+                    "model_name": model_name,
+                    "column_name": col_name,
+                    # catalog stores the DB-native type string in 'type'
+                    "column_type": col_info.get("type", ""),
+                    # dbt writes column descriptions into 'comment' in catalog
+                    "description": col_info.get("comment", ""),
+                })
+    return rows
+
+
+def parse_exposures(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract exposures from manifest.json exposures section."""
+    rows = []
+    for uid, exposure in manifest.get("exposures", {}).items():
+        owner = exposure.get("owner", {})
+        # owner may be a dict with 'name'/'email', or a plain string in older schemas
+        owner_name = owner.get("name", "") if isinstance(owner, dict) else str(owner)
+        rows.append({
+            "unique_id": uid,
+            "name": exposure.get("name", ""),
+            "type": exposure.get("type", ""),
+            "owner": owner_name,
+            "depends_on": exposure.get("depends_on", {}).get("nodes", []),
+        })
+    return rows

--- a/datametronome/pulse/dbt/metronome_pulse_dbt/virtual_tables.py
+++ b/datametronome/pulse/dbt/metronome_pulse_dbt/virtual_tables.py
@@ -1,0 +1,168 @@
+"""In-memory virtual table engine for dbt artifact data."""
+from __future__ import annotations
+from typing import Any
+
+# SQL keyword prefixes we detect to give a helpful error instead of a silent miss.
+_SQL_PREFIXES = ("SELECT", "INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "ALTER")
+
+
+class VirtualTableEngine:
+    """Stores parsed dbt artifact rows in named tables and supports filtering queries.
+
+    Query interface accepts either a string (table name → all rows) or a dict:
+
+        {
+            "table": "models",
+            "where": {"materialization": "table", "tags": "finance"},
+            "columns": ["name", "schema"],
+            "limit": 10,
+            "order_by": "name",        # prefix with "-" for descending
+        }
+
+    Where clause supports:
+    - Simple equality: {"materialization": "table"} matches rows where
+      materialization == "table"
+    - List containment: {"tags": "finance"} matches rows where "finance" is
+      in the tags list
+    """
+
+    def __init__(self) -> None:
+        self._tables: dict[str, list[dict[str, Any]]] = {}
+
+    def register_table(self, name: str, rows: list[dict[str, Any]]) -> None:
+        """Register (or overwrite) a virtual table with its rows."""
+        self._tables[name] = rows
+
+    def list_tables(self) -> list[str]:
+        """Return sorted list of registered table names."""
+        return sorted(self._tables.keys())
+
+    def get_table_info(self, table_name: str) -> list[dict[str, str]]:
+        """Return column names and inferred types for a table.
+
+        Types are inferred from the first row only. Returns an empty list for
+        unknown table names or tables with no rows.
+        """
+        rows = self._tables.get(table_name, [])
+        if not rows:
+            return []
+        return [
+            {"column_name": col, "column_type": _infer_type(val)}
+            for col, val in rows[0].items()
+        ]
+
+    def query(self, query_config: str | dict[str, Any]) -> list[dict[str, Any]]:
+        """Execute a query against virtual tables.
+
+        Args:
+            query_config: Either a table name string or a query dict.
+
+        Returns:
+            List of matching row dicts.
+
+        Raises:
+            ValueError: If the table is not found, or a raw SQL string is passed.
+        """
+        if isinstance(query_config, str):
+            return self._query_by_name(query_config.strip())
+
+        return self._query_by_dict(query_config)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _query_by_name(self, table_name: str) -> list[dict[str, Any]]:
+        """Return all rows for a table name string, rejecting SQL strings."""
+        upper = table_name.upper()
+        if any(upper.startswith(prefix) for prefix in _SQL_PREFIXES):
+            raise ValueError(
+                f"SQL queries are not supported by the dbt connector. "
+                f"Use table name strings or query dicts instead. "
+                f"Available tables: {', '.join(self.list_tables())}"
+            )
+        if table_name not in self._tables:
+            raise ValueError(
+                f"Virtual table '{table_name}' not found. "
+                f"Available tables: {', '.join(self.list_tables())}"
+            )
+        # Return a shallow copy so callers can't mutate internal state.
+        return list(self._tables[table_name])
+
+    def _query_by_dict(self, config: dict[str, Any]) -> list[dict[str, Any]]:
+        """Apply where / order_by / columns / limit from a query dict."""
+        table_name = config.get("table", "")
+        if table_name not in self._tables:
+            raise ValueError(
+                f"Virtual table '{table_name}' not found. "
+                f"Available tables: {', '.join(self.list_tables())}"
+            )
+
+        rows: list[dict[str, Any]] = self._tables[table_name]
+
+        where = config.get("where")
+        if where:
+            rows = [r for r in rows if _matches(r, where)]
+
+        order_by = config.get("order_by")
+        if order_by:
+            rows = _sort_rows(rows, order_by)
+
+        columns = config.get("columns")
+        if columns:
+            rows = [{k: r.get(k) for k in columns} for r in rows]
+
+        limit = config.get("limit")
+        if limit is not None:
+            rows = rows[:limit]
+
+        return rows
+
+
+# ------------------------------------------------------------------
+# Module-level helpers (no self needed — easier to test in isolation)
+# ------------------------------------------------------------------
+
+
+def _infer_type(value: Any) -> str:
+    """Return a simple type label for a Python value."""
+    if isinstance(value, bool):
+        # bool is a subclass of int, so this check must come first.
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return "text"
+
+
+def _matches(row: dict[str, Any], where: dict[str, Any]) -> bool:
+    """Return True if the row satisfies all where conditions.
+
+    List columns use containment semantics: {"tags": "finance"} is True when
+    "finance" appears anywhere in the tags list.  All other columns use strict
+    equality.
+    """
+    for key, expected in where.items():
+        actual = row.get(key)
+        if isinstance(actual, list):
+            if expected not in actual:
+                return False
+        elif actual != expected:
+            return False
+    return True
+
+
+def _sort_rows(rows: list[dict[str, Any]], order_by: str) -> list[dict[str, Any]]:
+    """Sort rows by a column name.  Prefix with '-' for descending order.
+
+    None values are sorted last regardless of direction so that missing data
+    never bubbles to the top.
+    """
+    desc = order_by.startswith("-")
+    col = order_by[1:] if desc else order_by
+    return sorted(rows, key=lambda r: (r.get(col) is None, r.get(col, "")), reverse=desc)

--- a/datametronome/pulse/dbt/pyproject.toml
+++ b/datametronome/pulse/dbt/pyproject.toml
@@ -1,0 +1,54 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "metronome-pulse-dbt"
+dynamic = ["version"]
+description = "Read-only dbt artifact connector for DataMetronome — exposes dbt project metadata as virtual queryable tables"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [
+    {name = "DataMetronome Team", email = "team@datametronome.dev"}
+]
+keywords = ["dbt", "data-quality", "connector", "async", "metadata"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Database",
+    "Framework :: AsyncIO",
+    "Typing :: Typed",
+]
+requires-python = ">=3.12"
+dependencies = [
+    "metronome-pulse-core>=0.1.0",
+    "httpx>=0.27.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.0.0",
+    "pytest-mock>=3.10.0",
+]
+test = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.0.0",
+    "pytest-mock>=3.10.0",
+]
+
+[tool.hatch.version]
+path = "metronome_pulse_dbt/__init__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["metronome_pulse_dbt"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/datametronome/pulse/dbt/tests/fixtures/catalog.json
+++ b/datametronome/pulse/dbt/tests/fixtures/catalog.json
@@ -1,0 +1,65 @@
+{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/catalog/v1/catalog.json",
+    "dbt_version": "1.7.0",
+    "generated_at": "2026-04-12T10:10:00Z"
+  },
+  "nodes": {
+    "model.my_project.stg_customers": {
+      "metadata": {
+        "name": "stg_customers",
+        "schema": "public",
+        "database": "analytics",
+        "type": "BASE TABLE"
+      },
+      "columns": {
+        "id": {"type": "integer", "comment": "Primary key"},
+        "name": {"type": "text", "comment": "Customer name"},
+        "email": {"type": "text", "comment": "Customer email"}
+      }
+    },
+    "model.my_project.stg_orders": {
+      "metadata": {
+        "name": "stg_orders",
+        "schema": "public",
+        "database": "analytics",
+        "type": "BASE TABLE"
+      },
+      "columns": {
+        "id": {"type": "integer", "comment": "Primary key"},
+        "customer_id": {"type": "integer", "comment": "FK to customers"},
+        "status": {"type": "text", "comment": "Order status"},
+        "amount": {"type": "numeric", "comment": "Order amount"}
+      }
+    },
+    "model.my_project.fct_orders": {
+      "metadata": {
+        "name": "fct_orders",
+        "schema": "public",
+        "database": "analytics",
+        "type": "BASE TABLE"
+      },
+      "columns": {
+        "order_id": {"type": "integer", "comment": ""},
+        "customer_name": {"type": "text", "comment": ""},
+        "status": {"type": "text", "comment": ""},
+        "amount": {"type": "numeric", "comment": ""}
+      }
+    }
+  },
+  "sources": {
+    "source.my_project.raw.customers": {
+      "metadata": {
+        "name": "customers",
+        "schema": "raw",
+        "database": "analytics",
+        "type": "BASE TABLE"
+      },
+      "columns": {
+        "id": {"type": "integer", "comment": ""},
+        "name": {"type": "text", "comment": ""},
+        "email": {"type": "text", "comment": ""}
+      }
+    }
+  }
+}

--- a/datametronome/pulse/dbt/tests/fixtures/manifest.json
+++ b/datametronome/pulse/dbt/tests/fixtures/manifest.json
@@ -1,0 +1,159 @@
+{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v11/manifest.json",
+    "dbt_version": "1.7.0",
+    "generated_at": "2026-04-12T10:00:00Z",
+    "project_name": "my_project"
+  },
+  "nodes": {
+    "model.my_project.stg_customers": {
+      "unique_id": "model.my_project.stg_customers",
+      "name": "stg_customers",
+      "resource_type": "model",
+      "schema": "public",
+      "database": "analytics",
+      "config": {"materialized": "view"},
+      "tags": ["staging"],
+      "description": "Staged customers from raw source",
+      "depends_on": {
+        "nodes": ["source.my_project.raw.customers"]
+      },
+      "path": "staging/stg_customers.sql"
+    },
+    "model.my_project.stg_orders": {
+      "unique_id": "model.my_project.stg_orders",
+      "name": "stg_orders",
+      "resource_type": "model",
+      "schema": "public",
+      "database": "analytics",
+      "config": {"materialized": "view"},
+      "tags": ["staging"],
+      "description": "Staged orders from raw source",
+      "depends_on": {
+        "nodes": ["source.my_project.raw.orders"]
+      },
+      "path": "staging/stg_orders.sql"
+    },
+    "model.my_project.fct_orders": {
+      "unique_id": "model.my_project.fct_orders",
+      "name": "fct_orders",
+      "resource_type": "model",
+      "schema": "public",
+      "database": "analytics",
+      "config": {"materialized": "table"},
+      "tags": ["marts", "finance"],
+      "description": "Orders fact table joining customers and orders",
+      "depends_on": {
+        "nodes": [
+          "model.my_project.stg_customers",
+          "model.my_project.stg_orders"
+        ]
+      },
+      "path": "marts/fct_orders.sql"
+    },
+    "test.my_project.not_null_stg_customers_id.abc123": {
+      "unique_id": "test.my_project.not_null_stg_customers_id.abc123",
+      "name": "not_null_stg_customers_id",
+      "resource_type": "test",
+      "schema": "public",
+      "database": "analytics",
+      "config": {"severity": "ERROR"},
+      "tags": [],
+      "description": "",
+      "depends_on": {
+        "nodes": ["model.my_project.stg_customers"]
+      },
+      "column_name": "id",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {"column_name": "id", "model": "ref('stg_customers')"}
+      },
+      "path": "generic_tests/not_null_stg_customers_id.sql"
+    },
+    "test.my_project.unique_stg_customers_id.def456": {
+      "unique_id": "test.my_project.unique_stg_customers_id.def456",
+      "name": "unique_stg_customers_id",
+      "resource_type": "test",
+      "schema": "public",
+      "database": "analytics",
+      "config": {"severity": "ERROR"},
+      "tags": [],
+      "description": "",
+      "depends_on": {
+        "nodes": ["model.my_project.stg_customers"]
+      },
+      "column_name": "id",
+      "test_metadata": {
+        "name": "unique",
+        "kwargs": {"column_name": "id", "model": "ref('stg_customers')"}
+      },
+      "path": "generic_tests/unique_stg_customers_id.sql"
+    },
+    "test.my_project.accepted_values_stg_orders_status.ghi789": {
+      "unique_id": "test.my_project.accepted_values_stg_orders_status.ghi789",
+      "name": "accepted_values_stg_orders_status",
+      "resource_type": "test",
+      "schema": "public",
+      "database": "analytics",
+      "config": {"severity": "WARN"},
+      "tags": ["data-quality"],
+      "description": "",
+      "depends_on": {
+        "nodes": ["model.my_project.stg_orders"]
+      },
+      "column_name": "status",
+      "test_metadata": {
+        "name": "accepted_values",
+        "kwargs": {
+          "column_name": "status",
+          "model": "ref('stg_orders')",
+          "values": ["placed", "shipped", "completed", "cancelled"]
+        }
+      },
+      "path": "generic_tests/accepted_values_stg_orders_status.sql"
+    }
+  },
+  "sources": {
+    "source.my_project.raw.customers": {
+      "unique_id": "source.my_project.raw.customers",
+      "name": "customers",
+      "source_name": "raw",
+      "schema": "raw",
+      "database": "analytics",
+      "identifier": "customers",
+      "freshness": {
+        "warn_after": {"count": 24, "period": "hour"},
+        "error_after": {"count": 48, "period": "hour"}
+      },
+      "description": "Raw customers table from operational database"
+    },
+    "source.my_project.raw.orders": {
+      "unique_id": "source.my_project.raw.orders",
+      "name": "orders",
+      "source_name": "raw",
+      "schema": "raw",
+      "database": "analytics",
+      "identifier": "orders",
+      "freshness": {
+        "warn_after": {"count": 6, "period": "hour"},
+        "error_after": {"count": 12, "period": "hour"}
+      },
+      "description": "Raw orders table from operational database"
+    }
+  },
+  "exposures": {
+    "exposure.my_project.weekly_report": {
+      "unique_id": "exposure.my_project.weekly_report",
+      "name": "weekly_report",
+      "type": "dashboard",
+      "owner": {
+        "name": "Finance Team",
+        "email": "finance@example.com"
+      },
+      "depends_on": {
+        "nodes": ["model.my_project.fct_orders"]
+      },
+      "description": "Weekly orders summary dashboard for finance"
+    }
+  }
+}

--- a/datametronome/pulse/dbt/tests/fixtures/run_results.json
+++ b/datametronome/pulse/dbt/tests/fixtures/run_results.json
@@ -1,0 +1,45 @@
+{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v5/run-results.json",
+    "dbt_version": "1.7.0",
+    "generated_at": "2026-04-12T10:05:00Z"
+  },
+  "results": [
+    {
+      "unique_id": "model.my_project.stg_customers",
+      "status": "success",
+      "execution_time": 1.23,
+      "message": "CREATE TABLE",
+      "failures": null
+    },
+    {
+      "unique_id": "model.my_project.fct_orders",
+      "status": "success",
+      "execution_time": 2.45,
+      "message": "CREATE TABLE",
+      "failures": null
+    },
+    {
+      "unique_id": "test.my_project.not_null_stg_customers_id.abc123",
+      "status": "pass",
+      "execution_time": 0.5,
+      "message": "Pass",
+      "failures": 0
+    },
+    {
+      "unique_id": "test.my_project.unique_stg_customers_id.def456",
+      "status": "pass",
+      "execution_time": 0.3,
+      "message": "Pass",
+      "failures": 0
+    },
+    {
+      "unique_id": "test.my_project.accepted_values_stg_orders_status.ghi789",
+      "status": "fail",
+      "execution_time": 0.8,
+      "message": "Got 2 results, configured to fail if != 0",
+      "failures": 2
+    }
+  ],
+  "elapsed_time": 5.28
+}

--- a/datametronome/pulse/dbt/tests/test_artifact_reader.py
+++ b/datametronome/pulse/dbt/tests/test_artifact_reader.py
@@ -1,0 +1,320 @@
+"""Tests for LocalArtifactReader and CloudArtifactReader."""
+
+import json
+import pathlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from metronome_pulse_dbt.artifact_reader import (
+    ArtifactReader,
+    CloudArtifactReader,
+    LocalArtifactReader,
+)
+from metronome_pulse_dbt.exceptions import (
+    ArtifactNotFoundError,
+    ArtifactParseError,
+    CloudApiError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MANIFEST_FIXTURE: dict = {
+    "metadata": {"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v10/manifest.json"},
+    "nodes": {},
+    "sources": {},
+}
+
+RUN_RESULTS_FIXTURE: dict = {
+    "metadata": {"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v4/run-results.json"},
+    "results": [],
+}
+
+CATALOG_FIXTURE: dict = {
+    "metadata": {"dbt_schema_version": "https://schemas.getdbt.com/dbt/catalog/v1/catalog.json"},
+    "nodes": {},
+    "sources": {},
+}
+
+
+def _write_json(directory: pathlib.Path, filename: str, data: dict) -> None:
+    (directory / filename).write_text(json.dumps(data), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Abstract interface
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_reader_is_abstract():
+    """ArtifactReader cannot be instantiated directly — it is an ABC."""
+    with pytest.raises(TypeError):
+        ArtifactReader()  # type: ignore[abstract]
+
+
+# ---------------------------------------------------------------------------
+# LocalArtifactReader — happy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_local_read_all_artifacts(tmp_path: pathlib.Path):
+    """All three artifact files present — all three return parsed dicts."""
+    target = tmp_path / "target"
+    target.mkdir()
+    _write_json(target, "manifest.json", MANIFEST_FIXTURE)
+    _write_json(target, "run_results.json", RUN_RESULTS_FIXTURE)
+    _write_json(target, "catalog.json", CATALOG_FIXTURE)
+
+    reader = LocalArtifactReader(str(tmp_path))
+
+    manifest = await reader.read_manifest()
+    run_results = await reader.read_run_results()
+    catalog = await reader.read_catalog()
+
+    assert manifest == MANIFEST_FIXTURE
+    assert run_results == RUN_RESULTS_FIXTURE
+    assert catalog == CATALOG_FIXTURE
+
+
+async def test_local_manifest_only(tmp_path: pathlib.Path):
+    """Only manifest present — run_results and catalog return None."""
+    target = tmp_path / "target"
+    target.mkdir()
+    _write_json(target, "manifest.json", MANIFEST_FIXTURE)
+
+    reader = LocalArtifactReader(str(tmp_path))
+
+    assert await reader.read_manifest() == MANIFEST_FIXTURE
+    assert await reader.read_run_results() is None
+    assert await reader.read_catalog() is None
+
+
+async def test_local_missing_manifest_raises(tmp_path: pathlib.Path):
+    """Missing manifest.json → ArtifactNotFoundError."""
+    target = tmp_path / "target"
+    target.mkdir()
+    # No manifest written
+
+    reader = LocalArtifactReader(str(tmp_path))
+
+    with pytest.raises(ArtifactNotFoundError, match="manifest.json"):
+        await reader.read_manifest()
+
+
+async def test_local_is_available_true(tmp_path: pathlib.Path):
+    """manifest.json present → is_available() returns True."""
+    target = tmp_path / "target"
+    target.mkdir()
+    _write_json(target, "manifest.json", MANIFEST_FIXTURE)
+
+    reader = LocalArtifactReader(str(tmp_path))
+
+    assert await reader.is_available() is True
+
+
+async def test_local_is_available_false(tmp_path: pathlib.Path):
+    """manifest.json absent → is_available() returns False."""
+    target = tmp_path / "target"
+    target.mkdir()
+
+    reader = LocalArtifactReader(str(tmp_path))
+
+    assert await reader.is_available() is False
+
+
+async def test_local_invalid_json_raises(tmp_path: pathlib.Path):
+    """Corrupt manifest.json → ArtifactParseError."""
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "manifest.json").write_text("{ not valid json }", encoding="utf-8")
+
+    reader = LocalArtifactReader(str(tmp_path))
+
+    with pytest.raises(ArtifactParseError, match="Invalid JSON"):
+        await reader.read_manifest()
+
+
+async def test_local_custom_target_path(tmp_path: pathlib.Path):
+    """Non-default target path is respected."""
+    custom_target = tmp_path / "compiled"
+    custom_target.mkdir()
+    _write_json(custom_target, "manifest.json", MANIFEST_FIXTURE)
+
+    reader = LocalArtifactReader(str(tmp_path), target_path="compiled")
+
+    assert await reader.read_manifest() == MANIFEST_FIXTURE
+
+
+# ---------------------------------------------------------------------------
+# CloudArtifactReader — mocked httpx
+# ---------------------------------------------------------------------------
+
+
+def _make_response(status_code: int, body: dict | None = None) -> MagicMock:
+    """Build a fake httpx.Response with the minimum interface we use."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = body or {}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _cloud_reader() -> CloudArtifactReader:
+    return CloudArtifactReader(
+        api_token="tok123",
+        account_id="42",
+        job_id="99",
+    )
+
+
+async def test_cloud_fetch_artifacts(mocker):
+    """Happy path: latest run resolved, manifest and run_results returned."""
+    runs_body = {"data": [{"id": 7}]}
+    manifest_body = MANIFEST_FIXTURE
+    run_results_body = RUN_RESULTS_FIXTURE
+
+    call_order = [
+        # _get_latest_run_id (read_manifest)
+        _make_response(200, runs_body),
+        _make_response(200, manifest_body),
+        # _get_latest_run_id (read_run_results)
+        _make_response(200, runs_body),
+        _make_response(200, run_results_body),
+    ]
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(side_effect=call_order)
+
+    mocker.patch("metronome_pulse_dbt.artifact_reader.httpx.AsyncClient", return_value=mock_client)
+
+    reader = _cloud_reader()
+
+    manifest = await reader.read_manifest()
+    run_results = await reader.read_run_results()
+
+    assert manifest == MANIFEST_FIXTURE
+    assert run_results == RUN_RESULTS_FIXTURE
+
+
+async def test_cloud_latest_run_lookup(mocker):
+    """Verifies the correct URL is constructed for the runs list endpoint."""
+    runs_body = {"data": [{"id": 55}]}
+    manifest_body = MANIFEST_FIXTURE
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(side_effect=[
+        _make_response(200, runs_body),
+        _make_response(200, manifest_body),
+    ])
+
+    mocker.patch("metronome_pulse_dbt.artifact_reader.httpx.AsyncClient", return_value=mock_client)
+
+    reader = CloudArtifactReader(
+        api_token="tok",
+        account_id="10",
+        job_id="20",
+        base_url="https://cloud.getdbt.com/api/v2",
+    )
+    await reader.read_manifest()
+
+    first_call_url = mock_client.get.call_args_list[0][0][0]
+    assert "accounts/10/runs/" in first_call_url
+    assert "job_definition_id=20" in first_call_url
+    assert "order_by=-finished_at" in first_call_url
+    assert "limit=1" in first_call_url
+
+
+async def test_cloud_404_optional_artifacts(mocker):
+    """404 for catalog → None (optional artifact absent is not an error)."""
+    runs_body = {"data": [{"id": 7}]}
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(side_effect=[
+        _make_response(200, runs_body),
+        _make_response(404),
+    ])
+
+    mocker.patch("metronome_pulse_dbt.artifact_reader.httpx.AsyncClient", return_value=mock_client)
+
+    reader = _cloud_reader()
+    result = await reader.read_catalog()
+
+    assert result is None
+
+
+async def test_cloud_auth_failure(mocker):
+    """401 on runs list → CloudApiError with correct status_code."""
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=_make_response(401))
+
+    mocker.patch("metronome_pulse_dbt.artifact_reader.httpx.AsyncClient", return_value=mock_client)
+
+    reader = _cloud_reader()
+
+    with pytest.raises(CloudApiError) as exc_info:
+        await reader.read_manifest()
+
+    assert exc_info.value.status_code == 401
+
+
+async def test_cloud_auth_failure_403(mocker):
+    """403 on artifact fetch → CloudApiError with status_code 403."""
+    runs_body = {"data": [{"id": 7}]}
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(side_effect=[
+        _make_response(200, runs_body),
+        _make_response(403),
+    ])
+
+    mocker.patch("metronome_pulse_dbt.artifact_reader.httpx.AsyncClient", return_value=mock_client)
+
+    reader = _cloud_reader()
+
+    with pytest.raises(CloudApiError) as exc_info:
+        await reader.read_manifest()
+
+    assert exc_info.value.status_code == 403
+
+
+async def test_cloud_is_available(mocker):
+    """Runs list returns 200 → is_available() is True."""
+    runs_body = {"data": [{"id": 7}]}
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=_make_response(200, runs_body))
+
+    mocker.patch("metronome_pulse_dbt.artifact_reader.httpx.AsyncClient", return_value=mock_client)
+
+    reader = _cloud_reader()
+    assert await reader.is_available() is True
+
+
+async def test_cloud_is_available_false_on_error(mocker):
+    """Network error → is_available() returns False rather than raising."""
+    import httpx as _httpx
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(side_effect=_httpx.ConnectError("timeout"))
+
+    mocker.patch("metronome_pulse_dbt.artifact_reader.httpx.AsyncClient", return_value=mock_client)
+
+    reader = _cloud_reader()
+    assert await reader.is_available() is False

--- a/datametronome/pulse/dbt/tests/test_connector.py
+++ b/datametronome/pulse/dbt/tests/test_connector.py
@@ -1,0 +1,311 @@
+"""Tests for DbtReadonlyPulse connector."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from metronome_pulse_dbt.connector import DbtReadonlyPulse
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
+
+
+def _write_artifacts(target_dir: pathlib.Path, *, include_run_results: bool = True, include_catalog: bool = True) -> None:
+    """Write fixture JSON files into target_dir for local-mode tests."""
+    manifest = json.loads((FIXTURES_DIR / "manifest.json").read_text())
+    (target_dir / "manifest.json").write_text(json.dumps(manifest))
+
+    if include_run_results:
+        run_results = json.loads((FIXTURES_DIR / "run_results.json").read_text())
+        (target_dir / "run_results.json").write_text(json.dumps(run_results))
+
+    if include_catalog:
+        catalog = json.loads((FIXTURES_DIR / "catalog.json").read_text())
+        (target_dir / "catalog.json").write_text(json.dumps(catalog))
+
+
+@pytest.fixture
+async def connected_local(tmp_path: pathlib.Path) -> DbtReadonlyPulse:
+    """Yield a connected DbtReadonlyPulse using local fixtures."""
+    target = tmp_path / "target"
+    target.mkdir()
+    _write_artifacts(target)
+
+    connector = DbtReadonlyPulse(mode="local", project_path=str(tmp_path))
+    await connector.connect()
+    return connector
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_local_mode_requires_path():
+    """Omitting project_path in local mode raises ValueError immediately."""
+    with pytest.raises(ValueError, match="project_path"):
+        DbtReadonlyPulse(mode="local", project_path="")
+
+
+def test_cloud_mode_requires_credentials():
+    """Missing cloud credentials raise ValueError immediately."""
+    with pytest.raises(ValueError, match="api_token"):
+        DbtReadonlyPulse(mode="cloud")
+
+
+def test_cloud_mode_partial_credentials_raises():
+    """Partial cloud credentials (missing job_id) raise ValueError."""
+    with pytest.raises(ValueError, match="api_token"):
+        DbtReadonlyPulse(mode="cloud", api_token="tok", account_id="42")
+
+
+def test_invalid_mode_raises():
+    """Unknown mode raises ValueError with the bad value in the message."""
+    with pytest.raises(ValueError, match="Unsupported mode.*ftp"):
+        DbtReadonlyPulse(mode="ftp", project_path="/tmp")
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_connect_local(tmp_path: pathlib.Path):
+    """Connecting with valid local artifacts sets connected=True."""
+    target = tmp_path / "target"
+    target.mkdir()
+    _write_artifacts(target)
+
+    connector = DbtReadonlyPulse(mode="local", project_path=str(tmp_path))
+    assert not await connector.is_connected()
+
+    await connector.connect()
+    assert await connector.is_connected()
+
+
+async def test_connect_idempotent(tmp_path: pathlib.Path):
+    """Calling connect() twice does not raise and stays connected."""
+    target = tmp_path / "target"
+    target.mkdir()
+    _write_artifacts(target)
+
+    connector = DbtReadonlyPulse(mode="local", project_path=str(tmp_path))
+    await connector.connect()
+    await connector.connect()  # second call must be a no-op
+    assert await connector.is_connected()
+
+
+async def test_close(connected_local: DbtReadonlyPulse):
+    """close() transitions connected → disconnected."""
+    await connected_local.close()
+    assert not await connected_local.is_connected()
+
+
+async def test_connect_cloud(mocker):
+    """Cloud mode: mocked reader methods → connect succeeds."""
+    # Fixtures loaded from real fixture files
+    manifest = json.loads((FIXTURES_DIR / "manifest.json").read_text())
+    run_results = json.loads((FIXTURES_DIR / "run_results.json").read_text())
+    catalog = json.loads((FIXTURES_DIR / "catalog.json").read_text())
+
+    mock_reader = MagicMock()
+    mock_reader.read_manifest = AsyncMock(return_value=manifest)
+    mock_reader.read_run_results = AsyncMock(return_value=run_results)
+    mock_reader.read_catalog = AsyncMock(return_value=catalog)
+
+    # Patch CloudArtifactReader so the connector uses our mock instead
+    mocker.patch(
+        "metronome_pulse_dbt.connector.CloudArtifactReader",
+        return_value=mock_reader,
+    )
+
+    connector = DbtReadonlyPulse(
+        mode="cloud",
+        api_token="tok",
+        account_id="42",
+        job_id="99",
+    )
+    await connector.connect()
+    assert await connector.is_connected()
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+async def test_context_manager(tmp_path: pathlib.Path):
+    """async with connects on entry and disconnects on exit."""
+    target = tmp_path / "target"
+    target.mkdir()
+    _write_artifacts(target)
+
+    connector = DbtReadonlyPulse(mode="local", project_path=str(tmp_path))
+    async with connector as ctx:
+        assert await ctx.is_connected()
+    assert not await connector.is_connected()
+
+
+# ---------------------------------------------------------------------------
+# query()
+# ---------------------------------------------------------------------------
+
+
+async def test_query_models(connected_local: DbtReadonlyPulse):
+    """query('models') returns model rows loaded from manifest."""
+    rows = await connected_local.query("models")
+    assert len(rows) == 3
+    names = {r["name"] for r in rows}
+    assert names == {"stg_customers", "stg_orders", "fct_orders"}
+
+
+async def test_query_dict(connected_local: DbtReadonlyPulse):
+    """query(dict) passes through to VirtualTableEngine with filtering."""
+    rows = await connected_local.query({
+        "table": "models",
+        "where": {"materialization": "table"},
+    })
+    assert len(rows) == 1
+    assert rows[0]["name"] == "fct_orders"
+
+
+async def test_query_not_connected():
+    """query() before connect() raises RuntimeError."""
+    connector = DbtReadonlyPulse(mode="local", project_path="/tmp/fake_does_not_matter")
+    with pytest.raises(RuntimeError, match="connect"):
+        await connector.query("models")
+
+
+async def test_query_test_results(connected_local: DbtReadonlyPulse):
+    """test_results virtual table contains only test-type results from run_results."""
+    rows = await connected_local.query("test_results")
+    # fixture run_results has 3 test entries (2 model runs are excluded)
+    assert len(rows) == 3
+    for row in rows:
+        assert row["unique_id"].startswith("test.")
+
+
+async def test_query_columns_table(connected_local: DbtReadonlyPulse):
+    """columns virtual table is populated from catalog.json."""
+    rows = await connected_local.query("columns")
+    assert len(rows) > 0
+    assert "column_name" in rows[0]
+    assert "column_type" in rows[0]
+
+
+# ---------------------------------------------------------------------------
+# query_with_params()
+# ---------------------------------------------------------------------------
+
+
+async def test_query_with_params_table_name(connected_local: DbtReadonlyPulse):
+    """query_with_params with a bare identifier delegates to query()."""
+    rows = await connected_local.query_with_params("models")
+    assert len(rows) == 3
+
+
+async def test_query_with_params_sql_raises(connected_local: DbtReadonlyPulse):
+    """query_with_params with a SQL string raises ValueError."""
+    with pytest.raises(ValueError, match="SQL queries are not supported"):
+        await connected_local.query_with_params("SELECT * FROM models")
+
+
+async def test_query_with_params_not_connected():
+    """query_with_params before connect() raises RuntimeError via query()."""
+    connector = DbtReadonlyPulse(mode="local", project_path="/tmp/fake")
+    with pytest.raises(RuntimeError, match="connect"):
+        await connector.query_with_params("models")
+
+
+# ---------------------------------------------------------------------------
+# list_tables() — returns dbt model names, not virtual table names
+# ---------------------------------------------------------------------------
+
+
+async def test_list_tables(connected_local: DbtReadonlyPulse):
+    """list_tables() returns model names from the models virtual table."""
+    names = await connected_local.list_tables()
+    assert set(names) == {"stg_customers", "stg_orders", "fct_orders"}
+
+
+async def test_list_tables_not_connected():
+    """list_tables() before connect() raises RuntimeError."""
+    connector = DbtReadonlyPulse(mode="local", project_path="/tmp/fake")
+    with pytest.raises(RuntimeError, match="connect"):
+        await connector.list_tables()
+
+
+# ---------------------------------------------------------------------------
+# get_table_info()
+# ---------------------------------------------------------------------------
+
+
+async def test_get_table_info(connected_local: DbtReadonlyPulse):
+    """get_table_info for a model with catalog data returns column list."""
+    cols = await connected_local.get_table_info("stg_customers")
+    assert len(cols) == 3
+    col_map = {c["column_name"]: c["column_type"] for c in cols}
+    assert col_map["id"] == "integer"
+    assert col_map["name"] == "text"
+    assert col_map["email"] == "text"
+
+
+async def test_get_table_info_no_catalog(tmp_path: pathlib.Path):
+    """When catalog is absent, get_table_info returns empty list."""
+    target = tmp_path / "target"
+    target.mkdir()
+    # Only manifest — no catalog
+    _write_artifacts(target, include_run_results=False, include_catalog=False)
+
+    connector = DbtReadonlyPulse(mode="local", project_path=str(tmp_path))
+    await connector.connect()
+
+    result = await connector.get_table_info("stg_customers")
+    assert result == []
+
+
+async def test_get_table_info_not_connected():
+    """get_table_info() before connect() raises RuntimeError."""
+    connector = DbtReadonlyPulse(mode="local", project_path="/tmp/fake")
+    with pytest.raises(RuntimeError, match="connect"):
+        await connector.get_table_info("stg_customers")
+
+
+# ---------------------------------------------------------------------------
+# Write operations (all must raise NotImplementedError)
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_raises(connected_local: DbtReadonlyPulse):
+    with pytest.raises(NotImplementedError, match="read-only"):
+        await connected_local.execute("DELETE FROM models")
+
+
+async def test_execute_many_raises(connected_local: DbtReadonlyPulse):
+    with pytest.raises(NotImplementedError, match="read-only"):
+        await connected_local.execute_many("INSERT INTO t VALUES (?)", [["a"]])
+
+
+async def test_write_raises(connected_local: DbtReadonlyPulse):
+    with pytest.raises(NotImplementedError, match="read-only"):
+        await connected_local.write([{"x": 1}], "models")
+
+
+# ---------------------------------------------------------------------------
+# Transactions (no-ops — must not raise)
+# ---------------------------------------------------------------------------
+
+
+async def test_transactions_are_noop(connected_local: DbtReadonlyPulse):
+    """Transaction methods are no-ops and return None without raising."""
+    await connected_local.begin_transaction()
+    await connected_local.commit_transaction()
+    await connected_local.rollback_transaction()

--- a/datametronome/pulse/dbt/tests/test_parsers.py
+++ b/datametronome/pulse/dbt/tests/test_parsers.py
@@ -1,0 +1,355 @@
+"""Tests for all six parser functions against the fixture artifacts."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from metronome_pulse_dbt.parsers import (
+    parse_columns,
+    parse_exposures,
+    parse_models,
+    parse_sources,
+    parse_test_results,
+    parse_tests,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manifest() -> dict:
+    return json.loads((FIXTURES / "manifest.json").read_text())
+
+
+@pytest.fixture
+def run_results() -> dict:
+    return json.loads((FIXTURES / "run_results.json").read_text())
+
+
+@pytest.fixture
+def catalog() -> dict:
+    return json.loads((FIXTURES / "catalog.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# parse_models
+# ---------------------------------------------------------------------------
+
+
+def test_parse_models(manifest):
+    """Three model nodes produce three rows with correct fields."""
+    rows = parse_models(manifest)
+
+    assert len(rows) == 3
+
+    by_name = {r["name"]: r for r in rows}
+    assert set(by_name) == {"stg_customers", "stg_orders", "fct_orders"}
+
+    stg = by_name["stg_customers"]
+    assert stg["unique_id"] == "model.my_project.stg_customers"
+    assert stg["schema"] == "public"
+    assert stg["database"] == "analytics"
+    assert stg["materialization"] == "view"
+    assert stg["tags"] == ["staging"]
+    assert stg["depends_on"] == ["source.my_project.raw.customers"]
+    assert stg["path"] == "staging/stg_customers.sql"
+
+    fct = by_name["fct_orders"]
+    assert fct["materialization"] == "table"
+    assert set(fct["depends_on"]) == {
+        "model.my_project.stg_customers",
+        "model.my_project.stg_orders",
+    }
+    assert "finance" in fct["tags"]
+
+
+def test_parse_models_empty():
+    """Empty manifest returns an empty list without error."""
+    assert parse_models({}) == []
+    assert parse_models({"nodes": {}}) == []
+
+
+def test_parse_models_skips_tests(manifest):
+    """Test nodes in manifest.nodes are not included in model output."""
+    rows = parse_models(manifest)
+    unique_ids = [r["unique_id"] for r in rows]
+    assert not any(uid.startswith("test.") for uid in unique_ids)
+
+
+# ---------------------------------------------------------------------------
+# parse_sources
+# ---------------------------------------------------------------------------
+
+
+def test_parse_sources(manifest):
+    """Two source entries produce two rows with correct fields."""
+    rows = parse_sources(manifest)
+
+    assert len(rows) == 2
+
+    by_name = {r["name"]: r for r in rows}
+    assert set(by_name) == {"customers", "orders"}
+
+    customers = by_name["customers"]
+    assert customers["unique_id"] == "source.my_project.raw.customers"
+    assert customers["source_name"] == "raw"
+    assert customers["schema"] == "raw"
+    assert customers["database"] == "analytics"
+    assert customers["identifier"] == "customers"
+    # Freshness thresholds are preserved as dicts, not flattened
+    assert customers["freshness_warn_after"] == {"count": 24, "period": "hour"}
+    assert customers["freshness_error_after"] == {"count": 48, "period": "hour"}
+
+    orders = by_name["orders"]
+    assert orders["freshness_warn_after"] == {"count": 6, "period": "hour"}
+
+
+def test_parse_sources_no_freshness():
+    """Sources without freshness config produce None for both fields."""
+    manifest = {
+        "sources": {
+            "source.proj.raw.tbl": {
+                "name": "tbl",
+                "source_name": "raw",
+                "schema": "raw",
+                "database": "db",
+            }
+        }
+    }
+    rows = parse_sources(manifest)
+    assert rows[0]["freshness_warn_after"] is None
+    assert rows[0]["freshness_error_after"] is None
+
+
+# ---------------------------------------------------------------------------
+# parse_tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_tests(manifest):
+    """Three test nodes produce three rows with correct type classification."""
+    rows = parse_tests(manifest)
+
+    assert len(rows) == 3
+
+    by_name = {r["name"]: r for r in rows}
+
+    # Both not_null and unique are generic tests (carry test_metadata)
+    nn = by_name["not_null_stg_customers_id"]
+    assert nn["test_type"] == "generic"
+    assert nn["model"] == "model.my_project.stg_customers"
+    assert nn["column_name"] == "id"
+    assert nn["severity"] == "ERROR"
+
+    av = by_name["accepted_values_stg_orders_status"]
+    assert av["test_type"] == "generic"
+    assert av["model"] == "model.my_project.stg_orders"
+    assert av["column_name"] == "status"
+    assert av["severity"] == "WARN"
+    assert "data-quality" in av["tags"]
+
+
+def test_parse_tests_singular_classification():
+    """A test node without test_metadata is classified as singular."""
+    manifest = {
+        "nodes": {
+            "test.proj.my_data_test.aaa": {
+                "name": "my_data_test",
+                "resource_type": "test",
+                "depends_on": {"nodes": ["model.proj.orders"]},
+                "column_name": "",
+                "config": {"severity": "ERROR"},
+                "tags": [],
+                # No test_metadata key → singular
+            }
+        }
+    }
+    rows = parse_tests(manifest)
+    assert len(rows) == 1
+    assert rows[0]["test_type"] == "singular"
+    assert rows[0]["model"] == "model.proj.orders"
+
+
+def test_parse_tests_skips_models(manifest):
+    """Model nodes in manifest.nodes are not included in test output."""
+    rows = parse_tests(manifest)
+    unique_ids = [r["unique_id"] for r in rows]
+    assert not any(uid.startswith("model.") for uid in unique_ids)
+
+
+# ---------------------------------------------------------------------------
+# parse_test_results
+# ---------------------------------------------------------------------------
+
+
+def test_parse_test_results(run_results):
+    """Only test results (unique_id starts with 'test.') are returned."""
+    rows = parse_test_results(run_results)
+
+    # 5 results total; 2 are model results → 3 test results expected
+    assert len(rows) == 3
+
+    by_id = {r["unique_id"]: r for r in rows}
+
+    not_null = by_id["test.my_project.not_null_stg_customers_id.abc123"]
+    assert not_null["status"] == "pass"
+    assert not_null["failures"] == 0
+    assert not_null["execution_time"] == 0.5
+
+    failing = by_id["test.my_project.accepted_values_stg_orders_status.ghi789"]
+    assert failing["status"] == "fail"
+    assert failing["failures"] == 2
+    assert "Got 2 results" in failing["message"]
+
+
+def test_parse_test_results_excludes_model_runs(run_results):
+    """Model run entries (unique_id starting 'model.') are filtered out."""
+    rows = parse_test_results(run_results)
+    unique_ids = [r["unique_id"] for r in rows]
+    assert not any(uid.startswith("model.") for uid in unique_ids)
+
+
+def test_parse_test_results_timestamp_attached(run_results):
+    """generated_at from metadata is attached to every test result row."""
+    rows = parse_test_results(run_results)
+    assert all(r["timestamp"] == "2026-04-12T10:05:00Z" for r in rows)
+
+
+def test_parse_test_results_empty():
+    """Empty run_results returns an empty list."""
+    assert parse_test_results({}) == []
+    assert parse_test_results({"results": []}) == []
+
+
+# ---------------------------------------------------------------------------
+# parse_columns
+# ---------------------------------------------------------------------------
+
+
+def test_parse_columns(catalog):
+    """Columns are extracted from both nodes and sources sections."""
+    rows = parse_columns(catalog)
+
+    # nodes: stg_customers(3) + stg_orders(4) + fct_orders(4) = 11
+    # sources: raw.customers(3)
+    assert len(rows) == 14
+
+    # Verify a specific column from the nodes section
+    stg_cust_cols = [r for r in rows if r["model_unique_id"] == "model.my_project.stg_customers"]
+    assert len(stg_cust_cols) == 3
+
+    col_names = {r["column_name"] for r in stg_cust_cols}
+    assert col_names == {"id", "name", "email"}
+
+    id_col = next(r for r in stg_cust_cols if r["column_name"] == "id")
+    assert id_col["model_name"] == "stg_customers"
+    assert id_col["column_type"] == "integer"
+    assert id_col["description"] == "Primary key"
+
+
+def test_parse_columns_source_section(catalog):
+    """Columns from the sources section are included in output."""
+    rows = parse_columns(catalog)
+    source_rows = [r for r in rows if r["model_unique_id"].startswith("source.")]
+    # raw.customers has 3 columns
+    assert len(source_rows) == 3
+    assert all(r["model_name"] == "customers" for r in source_rows)
+
+
+def test_parse_columns_empty():
+    """Empty catalog returns an empty list."""
+    assert parse_columns({}) == []
+    assert parse_columns({"nodes": {}, "sources": {}}) == []
+
+
+# ---------------------------------------------------------------------------
+# parse_exposures
+# ---------------------------------------------------------------------------
+
+
+def test_parse_exposures(manifest):
+    """One exposure is parsed with correct type, owner, and depends_on."""
+    rows = parse_exposures(manifest)
+
+    assert len(rows) == 1
+    exp = rows[0]
+    assert exp["unique_id"] == "exposure.my_project.weekly_report"
+    assert exp["name"] == "weekly_report"
+    assert exp["type"] == "dashboard"
+    assert exp["owner"] == "Finance Team"
+    assert exp["depends_on"] == ["model.my_project.fct_orders"]
+
+
+def test_parse_exposures_empty():
+    """Manifest with no exposures key returns an empty list."""
+    assert parse_exposures({}) == []
+    assert parse_exposures({"exposures": {}}) == []
+
+
+def test_parse_exposures_string_owner():
+    """Older dbt schemas may store owner as a plain string instead of a dict."""
+    manifest = {
+        "exposures": {
+            "exposure.proj.report": {
+                "name": "report",
+                "type": "analysis",
+                "owner": "Alice",
+                "depends_on": {"nodes": []},
+            }
+        }
+    }
+    rows = parse_exposures(manifest)
+    assert rows[0]["owner"] == "Alice"
+
+
+# ---------------------------------------------------------------------------
+# Defensive: missing fields must not crash any parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_defensive_missing_fields():
+    """All parsers tolerate manifests where optional fields are absent."""
+    bare_manifest = {
+        "nodes": {
+            "model.p.bare_model": {"resource_type": "model"},
+            "test.p.bare_test": {"resource_type": "test"},
+        },
+        "sources": {"source.p.s.t": {}},
+        "exposures": {"exposure.p.exp": {}},
+    }
+    bare_run_results = {"results": [{"unique_id": "test.p.t"}]}
+    bare_catalog = {"nodes": {"model.p.m": {"columns": {"col": {}}}}}
+
+    # None of these should raise
+    models = parse_models(bare_manifest)
+    sources = parse_sources(bare_manifest)
+    tests = parse_tests(bare_manifest)
+    test_results = parse_test_results(bare_run_results)
+    columns = parse_columns(bare_catalog)
+    exposures = parse_exposures(bare_manifest)
+
+    assert len(models) == 1
+    assert models[0]["materialization"] == ""
+
+    assert len(sources) == 1
+    assert sources[0]["freshness_warn_after"] is None
+
+    assert len(tests) == 1
+    assert tests[0]["model"] == ""
+    assert tests[0]["severity"] == "ERROR"
+
+    assert len(test_results) == 1
+    assert test_results[0]["timestamp"] == ""
+
+    assert len(columns) == 1
+    assert columns[0]["column_type"] == ""
+
+    assert len(exposures) == 1
+    assert exposures[0]["type"] == ""
+    assert exposures[0]["owner"] == ""

--- a/datametronome/pulse/dbt/tests/test_real_artifacts.py
+++ b/datametronome/pulse/dbt/tests/test_real_artifacts.py
@@ -165,7 +165,7 @@ class TestSnowflakeConnector:
         async with DbtReadonlyPulse(mode="local", project_path=str(SNOWFLAKE_DIR)) as conn:
             models = await conn.query("models")
             if not models:
-                pytest.skip(reason="No models found")
+                pytest.skip("No models found")  # ty: ignore[too-many-positional-arguments]
 
             # Get materializations used
             mats = set(m["materialization"] for m in models)
@@ -184,7 +184,7 @@ class TestSnowflakeConnector:
         async with DbtReadonlyPulse(mode="local", project_path=str(SNOWFLAKE_DIR)) as conn:
             models = await conn.query("models")
             if not models:
-                pytest.skip(reason="No models")
+                pytest.skip("No models")  # ty: ignore[too-many-positional-arguments]
 
             # Try getting column info for the first model
             first_model = models[0]["name"]

--- a/datametronome/pulse/dbt/tests/test_real_artifacts.py
+++ b/datametronome/pulse/dbt/tests/test_real_artifacts.py
@@ -165,7 +165,7 @@ class TestSnowflakeConnector:
         async with DbtReadonlyPulse(mode="local", project_path=str(SNOWFLAKE_DIR)) as conn:
             models = await conn.query("models")
             if not models:
-                pytest.skip("No models found")
+                pytest.skip(reason="No models found")
 
             # Get materializations used
             mats = set(m["materialization"] for m in models)
@@ -184,7 +184,7 @@ class TestSnowflakeConnector:
         async with DbtReadonlyPulse(mode="local", project_path=str(SNOWFLAKE_DIR)) as conn:
             models = await conn.query("models")
             if not models:
-                pytest.skip("No models")
+                pytest.skip(reason="No models")
 
             # Try getting column info for the first model
             first_model = models[0]["name"]

--- a/datametronome/pulse/dbt/tests/test_real_artifacts.py
+++ b/datametronome/pulse/dbt/tests/test_real_artifacts.py
@@ -1,0 +1,331 @@
+"""End-to-end tests against real dbt artifacts downloaded from public projects.
+
+These tests validate that our parsers and connector work correctly with
+real-world dbt manifest/run_results/catalog files, not just our hand-crafted
+fixtures.
+
+Skipped if the artifacts have not been downloaded to /tmp/dbt-test-real/target/.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from metronome_pulse_dbt.artifact_reader import LocalArtifactReader
+from metronome_pulse_dbt.connector import DbtReadonlyPulse
+from metronome_pulse_dbt.parsers import (
+    parse_columns,
+    parse_exposures,
+    parse_models,
+    parse_sources,
+    parse_test_results,
+    parse_tests,
+)
+
+# ---------- Snowflake project (v11 manifest, all 3 artifacts) ----------
+
+SNOWFLAKE_DIR = Path("/tmp/dbt-test-real")
+SNOWFLAKE_MANIFEST = SNOWFLAKE_DIR / "target" / "manifest.json"
+SNOWFLAKE_RUN_RESULTS = SNOWFLAKE_DIR / "target" / "run_results.json"
+SNOWFLAKE_CATALOG = SNOWFLAKE_DIR / "target" / "catalog.json"
+
+has_snowflake = SNOWFLAKE_MANIFEST.exists()
+
+# ---------- Jaffle shop / dbt-docs (v9 manifest, catalog only) ----------
+
+JAFFLE_DIR = Path("/tmp/dbt-test-jaffle")
+JAFFLE_MANIFEST = JAFFLE_DIR / "target" / "manifest.json"
+JAFFLE_CATALOG = JAFFLE_DIR / "target" / "catalog.json"
+
+has_jaffle = JAFFLE_MANIFEST.exists()
+
+
+# ============================================================
+# Snowflake dbt project tests
+# ============================================================
+
+
+@pytest.mark.skipif(not has_snowflake, reason="Real Snowflake artifacts not downloaded")
+class TestSnowflakeArtifacts:
+    """Tests against a real Snowflake dbt project (v11 manifest, dbt 1.7.4)."""
+
+    @pytest.fixture
+    def manifest(self):
+        return json.loads(SNOWFLAKE_MANIFEST.read_text())
+
+    @pytest.fixture
+    def run_results(self):
+        return json.loads(SNOWFLAKE_RUN_RESULTS.read_text())
+
+    @pytest.fixture
+    def catalog(self):
+        return json.loads(SNOWFLAKE_CATALOG.read_text())
+
+    def test_manifest_metadata(self, manifest):
+        meta = manifest["metadata"]
+        assert "dbt_version" in meta
+        assert "generated_at" in meta
+        print(f"  dbt version: {meta['dbt_version']}")
+        print(f"  schema: {meta.get('dbt_schema_version', 'unknown')}")
+
+    def test_parse_models_non_empty(self, manifest):
+        models = parse_models(manifest)
+        assert len(models) > 0, "Expected at least 1 model"
+        print(f"  Found {len(models)} models")
+        for m in models[:5]:
+            print(f"    - {m['name']} ({m['materialization']}) in {m['schema']}")
+
+        # Every model should have required fields
+        for m in models:
+            assert m["unique_id"], f"Missing unique_id for {m}"
+            assert m["name"], f"Missing name for {m['unique_id']}"
+
+    def test_parse_sources(self, manifest):
+        sources = parse_sources(manifest)
+        print(f"  Found {len(sources)} sources")
+        for s in sources[:5]:
+            print(f"    - {s['source_name']}.{s['name']} in {s['schema']}")
+
+    def test_parse_tests(self, manifest):
+        tests = parse_tests(manifest)
+        assert len(tests) > 0, "Expected at least 1 test"
+        print(f"  Found {len(tests)} tests")
+        types = set(t["test_type"] for t in tests)
+        print(f"    Test types: {types}")
+        for t in tests[:5]:
+            print(f"    - {t['name']} ({t['test_type']}, severity={t['severity']})")
+
+    def test_parse_test_results(self, run_results):
+        results = parse_test_results(run_results)
+        print(f"  Found {len(results)} test results")
+        statuses = set(r["status"] for r in results)
+        print(f"    Statuses: {statuses}")
+        for r in results[:5]:
+            print(f"    - {r['unique_id']}: {r['status']} ({r['execution_time']:.2f}s)")
+
+    def test_parse_columns(self, catalog):
+        columns = parse_columns(catalog)
+        assert len(columns) > 0, "Expected columns from catalog"
+        print(f"  Found {len(columns)} columns across all models/sources")
+        # Group by model
+        models = set(c["model_name"] for c in columns)
+        print(f"    Across {len(models)} models/sources")
+
+    def test_parse_exposures(self, manifest):
+        exposures = parse_exposures(manifest)
+        print(f"  Found {len(exposures)} exposures")
+
+    async def test_artifact_reader(self):
+        reader = LocalArtifactReader(str(SNOWFLAKE_DIR), "target")
+        assert await reader.is_available()
+
+        manifest = await reader.read_manifest()
+        assert "nodes" in manifest
+        assert "metadata" in manifest
+
+        run_results = await reader.read_run_results()
+        assert run_results is not None
+        assert "results" in run_results
+
+        catalog = await reader.read_catalog()
+        assert catalog is not None
+        assert "nodes" in catalog
+
+
+@pytest.mark.skipif(not has_snowflake, reason="Real Snowflake artifacts not downloaded")
+class TestSnowflakeConnector:
+    """Full connector integration test against real Snowflake dbt artifacts."""
+
+    async def test_connect_and_query(self):
+        connector = DbtReadonlyPulse(mode="local", project_path=str(SNOWFLAKE_DIR))
+        await connector.connect()
+        assert await connector.is_connected()
+
+        # Query all virtual tables
+        models = await connector.query("models")
+        sources = await connector.query("sources")
+        tests = await connector.query("tests")
+
+        print(f"\n  Models: {len(models)}")
+        print(f"  Sources: {len(sources)}")
+        print(f"  Tests: {len(tests)}")
+
+        assert len(models) > 0
+
+        # list_tables returns model names
+        table_names = await connector.list_tables()
+        print(f"  list_tables() returned {len(table_names)} model names")
+        assert len(table_names) == len(models)
+
+        await connector.close()
+
+    async def test_query_with_filters(self):
+        async with DbtReadonlyPulse(mode="local", project_path=str(SNOWFLAKE_DIR)) as conn:
+            models = await conn.query("models")
+            if not models:
+                pytest.skip("No models found")
+
+            # Get materializations used
+            mats = set(m["materialization"] for m in models)
+            print(f"  Materializations: {mats}")
+
+            # Filter by first materialization found
+            first_mat = next(iter(mats))
+            filtered = await conn.query({
+                "table": "models",
+                "where": {"materialization": first_mat},
+            })
+            print(f"  Models with materialization='{first_mat}': {len(filtered)}")
+            assert all(m["materialization"] == first_mat for m in filtered)
+
+    async def test_get_table_info(self):
+        async with DbtReadonlyPulse(mode="local", project_path=str(SNOWFLAKE_DIR)) as conn:
+            models = await conn.query("models")
+            if not models:
+                pytest.skip("No models")
+
+            # Try getting column info for the first model
+            first_model = models[0]["name"]
+            cols = await conn.get_table_info(first_model)
+            print(f"  Columns for '{first_model}': {len(cols)}")
+            if cols:
+                for c in cols[:5]:
+                    print(f"    - {c['column_name']}: {c['column_type']}")
+
+    async def test_test_results_available(self):
+        async with DbtReadonlyPulse(mode="local", project_path=str(SNOWFLAKE_DIR)) as conn:
+            try:
+                results = await conn.query("test_results")
+                print(f"  Test results: {len(results)}")
+                for r in results[:5]:
+                    print(f"    - {r['unique_id']}: {r['status']}")
+            except ValueError:
+                print("  No test_results table (no run_results.json)")
+
+    async def test_columns_virtual_table(self):
+        async with DbtReadonlyPulse(mode="local", project_path=str(SNOWFLAKE_DIR)) as conn:
+            try:
+                columns = await conn.query("columns")
+                print(f"  Total columns: {len(columns)}")
+                # Verify structure
+                if columns:
+                    first = columns[0]
+                    assert "model_name" in first
+                    assert "column_name" in first
+                    assert "column_type" in first
+            except ValueError:
+                print("  No columns table (no catalog.json)")
+
+    async def test_query_with_params_table_name(self):
+        async with DbtReadonlyPulse(mode="local", project_path=str(SNOWFLAKE_DIR)) as conn:
+            # query_with_params should work for plain table identifiers
+            models = await conn.query_with_params("models")
+            assert len(models) > 0
+
+    async def test_query_with_params_sql_rejected(self):
+        async with DbtReadonlyPulse(mode="local", project_path=str(SNOWFLAKE_DIR)) as conn:
+            with pytest.raises(ValueError, match="SQL queries are not supported"):
+                await conn.query_with_params("SELECT * FROM models")
+
+    async def test_write_operations_rejected(self):
+        async with DbtReadonlyPulse(mode="local", project_path=str(SNOWFLAKE_DIR)) as conn:
+            with pytest.raises(NotImplementedError):
+                await conn.execute("CREATE TABLE foo (id int)")
+            with pytest.raises(NotImplementedError):
+                await conn.execute_many("INSERT INTO foo VALUES (?)", [[1], [2]])
+            with pytest.raises(NotImplementedError):
+                await conn.write([{"a": 1}], "foo")
+
+
+# ============================================================
+# Jaffle shop / dbt-docs tests
+# ============================================================
+
+
+@pytest.mark.skipif(not has_jaffle, reason="Jaffle shop artifacts not downloaded")
+class TestJaffleShopArtifacts:
+    """Tests against dbt-labs/dbt-docs jaffle_shop artifacts (v9 manifest)."""
+
+    @pytest.fixture
+    def manifest(self):
+        return json.loads(JAFFLE_MANIFEST.read_text())
+
+    @pytest.fixture
+    def catalog(self):
+        return json.loads(JAFFLE_CATALOG.read_text())
+
+    def test_manifest_metadata(self, manifest):
+        meta = manifest["metadata"]
+        print(f"  dbt version: {meta['dbt_version']}")
+        print(f"  project: {meta.get('project_name', 'unknown')}")
+        print(f"  adapter: {meta.get('adapter_type', 'unknown')}")
+
+    def test_parse_models(self, manifest):
+        models = parse_models(manifest)
+        print(f"  Found {len(models)} models")
+        for m in models[:10]:
+            print(f"    - {m['name']} ({m['materialization']}) tags={m['tags']}")
+        assert len(models) > 0
+
+    def test_parse_sources(self, manifest):
+        sources = parse_sources(manifest)
+        print(f"  Found {len(sources)} sources")
+        for s in sources:
+            print(f"    - {s['source_name']}.{s['name']}")
+
+    def test_parse_tests(self, manifest):
+        tests = parse_tests(manifest)
+        print(f"  Found {len(tests)} tests")
+        generic_count = sum(1 for t in tests if t["test_type"] == "generic")
+        singular_count = sum(1 for t in tests if t["test_type"] == "singular")
+        print(f"    Generic: {generic_count}, Singular: {singular_count}")
+
+    def test_parse_columns(self, catalog):
+        columns = parse_columns(catalog)
+        print(f"  Found {len(columns)} columns")
+        models = set(c["model_name"] for c in columns)
+        print(f"    Across {len(models)} models/sources: {models}")
+
+    async def test_connector_full_lifecycle(self):
+        """Full lifecycle: connect, query, list_tables, get_table_info, close."""
+        connector = DbtReadonlyPulse(mode="local", project_path=str(JAFFLE_DIR))
+        await connector.connect()
+
+        models = await connector.query("models")
+        sources = await connector.query("sources")
+        tests = await connector.query("tests")
+        exposures = await connector.query("exposures")
+
+        print(f"\n  Jaffle shop summary:")
+        print(f"    Models: {len(models)}")
+        print(f"    Sources: {len(sources)}")
+        print(f"    Tests: {len(tests)}")
+        print(f"    Exposures: {len(exposures)}")
+
+        # list_tables
+        tables = await connector.list_tables()
+        print(f"    list_tables: {tables}")
+
+        # get_table_info for each model
+        for name in tables[:3]:
+            cols = await connector.get_table_info(name)
+            print(f"    {name} columns: {[c['column_name'] for c in cols]}")
+
+        # Filtered query
+        if models:
+            # Find a tag that exists
+            all_tags = set()
+            for m in models:
+                all_tags.update(m.get("tags", []))
+            if all_tags:
+                tag = next(iter(all_tags))
+                tagged = await connector.query({
+                    "table": "models",
+                    "where": {"tags": tag},
+                })
+                print(f"    Models with tag '{tag}': {len(tagged)}")
+
+        await connector.close()
+        assert not await connector.is_connected()

--- a/datametronome/pulse/dbt/tests/test_signature_alignment.py
+++ b/datametronome/pulse/dbt/tests/test_signature_alignment.py
@@ -1,0 +1,34 @@
+"""Verify DbtReadonlyPulse satisfies PulseProtocol structurally."""
+
+from metronome_pulse_core.protocol import PulseProtocol
+from metronome_pulse_dbt import DbtReadonlyPulse
+
+
+def test_satisfies_pulse_protocol():
+    """DbtReadonlyPulse must satisfy the structural PulseProtocol."""
+    connector = DbtReadonlyPulse(mode="local", project_path="/tmp/fake")
+    assert isinstance(connector, PulseProtocol)
+
+
+def test_has_required_methods():
+    """Verify all PulseProtocol methods exist on DbtReadonlyPulse."""
+    required = [
+        "connect",
+        "close",
+        "query",
+        "query_with_params",
+        "execute",
+        "execute_many",
+        "write",
+        "list_tables",
+        "get_table_info",
+        "begin_transaction",
+        "commit_transaction",
+        "rollback_transaction",
+        "__aenter__",
+        "__aexit__",
+    ]
+    connector = DbtReadonlyPulse(mode="local", project_path="/tmp/fake")
+    for method in required:
+        assert hasattr(connector, method), f"Missing method: {method}"
+        assert callable(getattr(connector, method)), f"{method} is not callable"

--- a/datametronome/pulse/dbt/tests/test_virtual_tables.py
+++ b/datametronome/pulse/dbt/tests/test_virtual_tables.py
@@ -1,0 +1,118 @@
+import pytest
+from metronome_pulse_dbt.virtual_tables import VirtualTableEngine
+
+
+@pytest.fixture
+def engine():
+    e = VirtualTableEngine()
+    e.register_table("models", [
+        {"name": "stg_customers", "schema": "public", "materialization": "view", "tags": ["staging", "customers"]},
+        {"name": "stg_orders", "schema": "public", "materialization": "view", "tags": ["staging"]},
+        {"name": "fct_orders", "schema": "public", "materialization": "table", "tags": ["marts", "finance"]},
+    ])
+    e.register_table("sources", [
+        {"name": "customers", "source_name": "raw", "schema": "raw"},
+        {"name": "orders", "source_name": "raw", "schema": "raw"},
+    ])
+    return e
+
+
+def test_list_tables(engine):
+    assert engine.list_tables() == ["models", "sources"]
+
+
+def test_query_string(engine):
+    rows = engine.query("models")
+    assert len(rows) == 3
+    assert rows[0]["name"] == "stg_customers"
+
+
+def test_query_string_unknown_table(engine):
+    with pytest.raises(ValueError, match="not found"):
+        engine.query("nonexistent")
+
+
+def test_query_sql_raises(engine):
+    with pytest.raises(ValueError, match="SQL queries are not supported"):
+        engine.query("SELECT * FROM models")
+
+
+def test_query_dict_basic(engine):
+    rows = engine.query({"table": "models"})
+    assert len(rows) == 3
+
+
+def test_query_where_equality(engine):
+    rows = engine.query({"table": "models", "where": {"materialization": "table"}})
+    assert len(rows) == 1
+    assert rows[0]["name"] == "fct_orders"
+
+
+def test_query_where_list_containment(engine):
+    rows = engine.query({"table": "models", "where": {"tags": "finance"}})
+    assert len(rows) == 1
+    assert rows[0]["name"] == "fct_orders"
+
+
+def test_query_columns(engine):
+    rows = engine.query({"table": "models", "columns": ["name", "schema"]})
+    assert len(rows) == 3
+    for row in rows:
+        assert set(row.keys()) == {"name", "schema"}
+
+
+def test_query_limit(engine):
+    rows = engine.query({"table": "models", "limit": 2})
+    assert len(rows) == 2
+
+
+def test_query_order_by(engine):
+    rows = engine.query({"table": "models", "order_by": "name"})
+    names = [r["name"] for r in rows]
+    assert names == sorted(names)
+
+
+def test_query_order_by_desc(engine):
+    rows = engine.query({"table": "models", "order_by": "-name"})
+    names = [r["name"] for r in rows]
+    assert names == sorted(names, reverse=True)
+
+
+def test_query_combined(engine):
+    # where: staging tags, columns: name only, order_by name desc, limit 1
+    rows = engine.query({
+        "table": "models",
+        "where": {"tags": "staging"},
+        "columns": ["name"],
+        "order_by": "-name",
+        "limit": 1,
+    })
+    assert len(rows) == 1
+    assert rows[0] == {"name": "stg_orders"}
+
+
+def test_get_table_info(engine):
+    info = engine.get_table_info("models")
+    # First row has: name (text), schema (text), materialization (text), tags (array)
+    col_map = {c["column_name"]: c["column_type"] for c in info}
+    assert col_map["name"] == "text"
+    assert col_map["schema"] == "text"
+    assert col_map["materialization"] == "text"
+    assert col_map["tags"] == "array"
+
+
+def test_get_table_info_empty_table():
+    e = VirtualTableEngine()
+    e.register_table("empty", [])
+    assert e.get_table_info("empty") == []
+
+
+def test_get_table_info_unknown_table(engine):
+    assert engine.get_table_info("nonexistent") == []
+
+
+def test_register_overwrites(engine):
+    engine.register_table("models", [{"name": "only_one"}])
+    rows = engine.query("models")
+    assert len(rows) == 1
+    assert rows[0]["name"] == "only_one"


### PR DESCRIPTION
## Summary

- New `metronome-pulse-dbt` package (`datametronome/pulse/dbt/`) that reads dbt project artifacts and exposes metadata as virtual queryable tables
- Supports **local filesystem** and **dbt Cloud API** as artifact sources
- 6 virtual tables: `models`, `sources`, `tests`, `test_results`, `columns`, `exposures`
- Query interface with filtering, column selection, ordering, and limits (no SQL — metadata only)
- Podium integration: `dbt` registered as a stave data source type across connector factory, connection tester, encryption, schema validation, and data preview

### Architecture

```
Stave(type="dbt", config={mode:"local", project_path:"/..."})
  → ConnectorFactory → DbtReadonlyPulse
    → ArtifactReader (Local or Cloud)
      → loads manifest.json, run_results.json, catalog.json
    → Parsers normalize into row dicts
    → VirtualTableEngine serves queries
```

### New files (Pulse package)
- `artifact_reader.py` — ABC + `LocalArtifactReader` + `CloudArtifactReader`
- `parsers.py` — 6 parsers for manifest/run_results/catalog normalization
- `virtual_tables.py` — In-memory query engine with filter/order/limit
- `connector.py` — `DbtReadonlyPulse` implementing `Pulse`, `Readable`, satisfying `PulseProtocol`
- `exceptions.py` — `DbtConnectorError`, `ArtifactNotFoundError`, `ArtifactParseError`, `CloudApiError`

### Modified files (Podium integration)
- `connector_factory.py` — `_build_dbt_connector()` (always read-only)
- `encryption.py` — `"dbt": ["api_token"]` in `SENSITIVE_FIELDS`
- `connection_tester.py` — `_test_dbt_connection()` returning model/source/test counts
- `staves/model.py`, `schema.py`, `router.py` — `"dbt"` added to type lists
- `staves/service.py` — dbt support in `_call_list_tables()` and `_fetch_preview_data()`

### Bug fix discovered during real-world testing
- `get_table_info()` now uses case-insensitive matching — Snowflake uppercases catalog names (`STG_ERROR_DATA`) while manifest keeps lowercase (`stg_error_data`)

## Test plan

- [x] 78 unit tests (artifact readers, parsers, virtual tables, connector, protocol alignment)
- [x] 22 integration tests against real dbt artifacts (Snowflake dbt 1.7.4 v11 manifest + jaffle_shop dbt 1.5.0 v9 manifest)
- [x] 8 Podium integration tests (factory dispatch, type validation, encryption config)
- [x] 618 existing Podium tests pass (no regressions)
- [ ] Manual: create dbt stave via API, test-connection, list-tables
- [ ] Docker: `make up` starts without import errors